### PR TITLE
fix: widen analyzer dependency constraint, release 0.6.1

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1
+
+- **Dependencies**:
+    - Widened the `analyzer` constraint from `^6.0.0` to `>=6.0.0 <15.0.0` to cover the current latest `analyzer` release and improve the pub.dev "supports latest dependencies" score.
+
 ## 0.6.0
 
 - **MCP Integration**:

--- a/packages/riverpod_devtools/extension/devtools/build/flutter_bootstrap.js
+++ b/packages/riverpod_devtools/extension/devtools/build/flutter_bootstrap.js
@@ -11,6 +11,6 @@ _flutter.buildConfig = {"engineRevision":"18b71d647a292a980abb405ac7d16fe1f0b204
 
 _flutter.loader.load({
   serviceWorkerSettings: {
-    serviceWorkerVersion: "4036893463"
+    serviceWorkerVersion: "3566782178"
   }
 });

--- a/packages/riverpod_devtools/extension/devtools/build/flutter_service_worker.js
+++ b/packages/riverpod_devtools/extension/devtools/build/flutter_service_worker.js
@@ -3,8 +3,8 @@ const MANIFEST = 'flutter-app-manifest';
 const TEMP = 'flutter-temp-cache';
 const CACHE_NAME = 'flutter-app-cache';
 
-const RESOURCES = {"flutter_bootstrap.js": "f84ad5858af1e80298a62cc4ed40b020",
-"version.json": "efa59dada7f971d9795d9bc208742ad0",
+const RESOURCES = {"flutter_bootstrap.js": "52a4994d1c7ff0f69a5f6bf6ffe62108",
+"version.json": "60b6756132dbe67415c9a4e929a9daa8",
 "index.html": "2feffa0fadf0e3a588a70eb93236cacc",
 "/": "2feffa0fadf0e3a588a70eb93236cacc",
 "main.dart.js": "1de9708817851fa89bee9b65304c3858",

--- a/packages/riverpod_devtools/extension/devtools/build/version.json
+++ b/packages/riverpod_devtools/extension/devtools/build/version.json
@@ -1,1 +1,1 @@
-{"app_name":"riverpod_devtools_extension","version":"0.6.0","package_name":"riverpod_devtools_extension"}
+{"app_name":"riverpod_devtools_extension","version":"0.6.1","package_name":"riverpod_devtools_extension"}

--- a/packages/riverpod_devtools/extension/devtools/config.yaml
+++ b/packages/riverpod_devtools/extension/devtools/config.yaml
@@ -1,4 +1,4 @@
 name: riverpod_devtools
 issueTracker: https://github.com/yutsuki3/riverpod_devtools/issues
-version: 0.6.0
+version: 0.6.1
 materialIconCodePoint: "0xe97a"

--- a/packages/riverpod_devtools/pubspec.yaml
+++ b/packages/riverpod_devtools/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_devtools
 description: DevTools extension for Riverpod - inspect and monitor your providers in real-time.
-version: 0.6.0
+version: 0.6.1
 repository: https://github.com/yutsuki3/riverpod_devtools
 homepage: https://github.com/yutsuki3/riverpod_devtools
 issue_tracker: https://github.com/yutsuki3/riverpod_devtools/issues
@@ -24,7 +24,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_riverpod: ">=2.3.0 <4.0.0"
-  analyzer: ^6.0.0
+  analyzer: ">=6.0.0 <15.0.0"
   path: ^1.9.0
   dart_mcp: ^0.5.1
 

--- a/packages/riverpod_devtools_extension/pubspec.yaml
+++ b/packages/riverpod_devtools_extension/pubspec.yaml
@@ -2,7 +2,7 @@ name: riverpod_devtools_extension
 description: DevTools extension UI for riverpod_devtools
 publish_to: 'none'
 
-version: 0.6.0
+version: 0.6.1
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
## Summary
- pub.dev's "Support up-to-date dependencies" score (30/40) flagged `analyzer: ^6.0.0` for not supporting the latest stable `analyzer` release — the caret constraint excludes everything from `7.0.0` onward, while the actual latest is `14.0.0`.
- Widened the constraint to `analyzer: ">=6.0.0 <15.0.0"`, which covers the current latest release while keeping an explicit upper bound (an unbounded constraint trips `pub publish`'s own "no upper bound" warning).
- Bumped `riverpod_devtools` to `0.6.1` and synced the version across `extension/devtools/config.yaml` and `riverpod_devtools_extension/pubspec.yaml` via the existing `tool/release.sh` process, then rebuilt and copied the DevTools extension web assets.
- Added a `0.6.1` CHANGELOG entry.

## Verification
Local Flutter (3.29.2) can't even resolve this project (`environment.flutter: ">=3.32.0"`), and `analyzer 14.0.0` itself requires Dart `^3.11.0`, so I used a cached Flutter `3.41.9` (Dart `3.11.5`) to validate end-to-end:
- `flutter pub get` resolves cleanly; the real-world resolvable `analyzer` version today is `10.0.1` (the highest version compatible with the Flutter SDK's own pinned `meta: 1.17.0` — an ecosystem-wide ceiling outside this package's control, not something the constraint change affects).
- `flutter analyze` — no issues.
- `flutter test` — all 33 tests pass.
- `dart run riverpod_devtools:analyze` against the bundled example app — still correctly extracts providers/dependencies via `package:analyzer`'s AST APIs.
- `flutter pub downgrade` (lower-bound check) + `flutter analyze` — still no issues, so the existing 20/20 "compatible with lower bounds" score is unaffected.
- `flutter pub publish --dry-run` — only the expected "uncommitted git state" notice (no dependency warnings).

## Test plan
- [ ] Confirm pub.dev re-scores "Support up-to-date dependencies" higher after this version is published
- [ ] `flutter pub publish --dry-run` clean on CI