### PR TITLE
fix(example): replace StateProvider with Notifier for riverpod 2.x/3.x compat

### DIFF
--- a/packages/riverpod_devtools/example/lib/main.dart
+++ b/packages/riverpod_devtools/example/lib/main.dart
@@ -4,8 +4,23 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_devtools/riverpod_devtools.dart';
 import 'providers.dart';
 
-final counterProvider = StateProvider<int>((ref) => 0);
-final nameProvider = StateProvider<String>((ref) => 'Flutter');
+class Counter extends Notifier<int> {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+}
+
+final counterProvider = NotifierProvider<Counter, int>(Counter.new);
+
+class Name extends Notifier<String> {
+  @override
+  String build() => 'Flutter';
+
+  void set(String value) => state = value;
+}
+
+final nameProvider = NotifierProvider<Name, String>(Name.new);
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -82,7 +97,7 @@ class HomePage extends ConsumerWidget {
 
               // Action buttons
               ElevatedButton(
-                onPressed: () => ref.read(nameProvider.notifier).state = 'Riverpod',
+                onPressed: () => ref.read(nameProvider.notifier).set('Riverpod'),
                 child: const Text('Change Name'),
               ),
             ],
@@ -90,7 +105,7 @@ class HomePage extends ConsumerWidget {
         ),
       ),
       floatingActionButton: FloatingActionButton(
-        onPressed: () => ref.read(counterProvider.notifier).state++,
+        onPressed: () => ref.read(counterProvider.notifier).increment(),
         child: const Icon(Icons.add),
       ),
     );


### PR DESCRIPTION
## Summary
- `packages/riverpod_devtools/example/pubspec.yaml` allows `flutter_riverpod: '>=2.3.0 <4.0.0'`. In riverpod 3.x, `StateProvider` moved out of the main `flutter_riverpod.dart` barrel into a separate `legacy.dart` entry point. A fresh `pub get` that resolves to 3.x (the default, since pub prefers the highest version satisfying the constraint) fails to compile with `The function 'StateProvider' isn't defined`.
- Importing `legacy.dart` isn't a safe fix either — that file doesn't exist before riverpod 3.0, so it would break the package's lower-bound (`pub downgrade` to `2.3.0`) compatibility instead.
- Replaced `StateProvider` with `NotifierProvider`/`Notifier`, which has the same public API across the entire `2.3.0–4.0.0` range, so no version-conditional imports are needed.
- Bundling into the not-yet-published `0.6.1` (see #42) rather than shipping a broken bundled example under that version.

## Verification
Using a cached Flutter `3.41.9` (the only locally available SDK that satisfies this repo's `>=3.32.0` floor):
- `flutter analyze` — no issues against the upgraded resolution (`flutter_riverpod 3.3.2`)
- `flutter pub downgrade` + `flutter analyze` — no issues against the lower bound (`flutter_riverpod 2.3.0`)

## Test plan
- [ ] `cd packages/riverpod_devtools/example && flutter pub get && flutter analyze`
- [ ] `flutter pub downgrade && flutter analyze` (lower-bound sanity check)