### PR TITLE
docs: add 0.6.1 CHANGELOG entry for the StateProvider fix

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - **Dependencies**:
     - Widened the `analyzer` constraint from `^6.0.0` to `>=6.0.0 <15.0.0` to cover the current latest `analyzer` release and improve the pub.dev "supports latest dependencies" score.
+- **Example**:
+    - Replaced `StateProvider` with `NotifierProvider`/`Notifier` in the bundled example so it keeps compiling across the full supported `flutter_riverpod` range (`2.3.0`–`4.0.0`), including when resolved to Riverpod 3.x.
 
 ## 0.6.0
 


### PR DESCRIPTION
## Summary
- Adds the missing CHANGELOG entry for #43 (StateProvider → Notifier example fix) under the existing `0.6.1` section.

## Test plan
- N/A (docs-only change)