### PR TITLE
docs: highlight MCP support in package README and pub.dev metadata

### DIFF
--- a/packages/riverpod_devtools/README.md
+++ b/packages/riverpod_devtools/README.md
@@ -1,18 +1,28 @@
 # riverpod_devtools
 
 [![pub package](https://img.shields.io/pub/v/riverpod_devtools.svg)](https://pub.dev/packages/riverpod_devtools)
+[![MCP](https://img.shields.io/badge/MCP-supported-blue)](https://modelcontextprotocol.io/)
 
-A [DevTools](https://flutter.dev/devtools) extension for [Riverpod](https://riverpod.dev) - inspect and monitor your providers in real-time.
+A [DevTools](https://flutter.dev/devtools) extension for [Riverpod](https://riverpod.dev) - inspect and monitor your providers in real-time. **Now meets [MCP](https://modelcontextprotocol.io/)**, so AI coding tools can read that same live provider state too.
 
 <img src="https://raw.githubusercontent.com/yutsuki3/riverpod_devtools/main/packages/riverpod_devtools/example/screenshot_044.png" width="100%" alt="Riverpod DevTools Demo" />
 
 ## Features
 
+- **AI Tool Integration (MCP)**: Let AI coding tools like Claude Code read live provider event logs via an optional bundled MCP server.
 - **Static Dependency Analysis**: Accurate provider dependency detection using CLI-based code analysis.
 - **Provider Graph**: Visualize the relationships between your providers with precise dependency data.
 - **State Inspector**: View the current state of your providers with type labels and optimized display.
 - **Event Log**: Track provider lifecycle events with hierarchical grouping and sub-events.
 - **Light Mode Support**: Seamlessly switch between light and dark themes.
+
+## 🤖 riverpod_devtools meets MCP
+
+Your AI coding tool normally only sees your source code — not what's actually happening while your app runs. This package bundles an optional [MCP](https://modelcontextprotocol.io/) server so tools like Claude Code can read **live** Riverpod provider event logs straight from your running app, and act on them:
+
+> "Look at the current provider logs and fix any behavior that differs from the spec."
+
+See [MCP.md](MCP.md) for setup — it takes one `.mcp.json` entry.
 
 ## Getting started
 
@@ -131,10 +141,6 @@ Version 0.5.0 removes runtime-based dependency detection. If you relied on depen
 3. Add the JSON file to your `pubspec.yaml` assets
 
 Event log and state inspection continue to work with only `RiverpodDevToolsObserver()` — the dependency graph requires static analysis.
-
-## Optional: AI Tool Integration (MCP)
-
-This package also bundles an optional [MCP](https://modelcontextprotocol.io/) server so AI tools like Claude Code can read live provider event logs from your running app. See [MCP.md](MCP.md) for setup.
 
 ## Additional information
 

--- a/packages/riverpod_devtools/pubspec.yaml
+++ b/packages/riverpod_devtools/pubspec.yaml
@@ -1,5 +1,5 @@
 name: riverpod_devtools
-description: DevTools extension for Riverpod - inspect and monitor your providers in real-time.
+description: DevTools extension for Riverpod - inspect providers in real-time, now with MCP support for AI coding tools.
 version: 0.6.1
 repository: https://github.com/yutsuki3/riverpod_devtools
 homepage: https://github.com/yutsuki3/riverpod_devtools
@@ -10,7 +10,7 @@ topics:
   - devtools
   - state-management
   - debugging
-  - developer-tools
+  - mcp
 
 screenshots:
   - description: 'Riverpod DevTools interface showing Provider Graph, State Inspector, and Event Log'


### PR DESCRIPTION
## Summary
- Move MCP integration from a small note near the bottom of the README to a headline feature: badge, tagline, Features list entry, and a dedicated "meets MCP" section placed before Getting started
- Update pub.dev `description` and `topics` (swapped `developer-tools` → `mcp`) so the package surfaces in MCP-related searches

## Test plan
- [ ] Preview README rendering on GitHub/pub.dev (markdown/badges only, no app code touched)