### PR TITLE
chore: bump riverpod_devtools to 0.6.2

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.2
+
+- **Docs**:
+    - Highlighted MCP support in the README (badge, tagline, Features list, dedicated section) and pub.dev metadata (`description`, `topics`) — no code changes.
+
 ## 0.6.1
 
 - **Dependencies**:

--- a/packages/riverpod_devtools/pubspec.yaml
+++ b/packages/riverpod_devtools/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_devtools
 description: DevTools extension for Riverpod - inspect providers in real-time, now with MCP support for AI coding tools.
-version: 0.6.1
+version: 0.6.2
 repository: https://github.com/yutsuki3/riverpod_devtools
 homepage: https://github.com/yutsuki3/riverpod_devtools
 issue_tracker: https://github.com/yutsuki3/riverpod_devtools/issues


### PR DESCRIPTION
## Summary
- Bump version to 0.6.2 (docs-only release) so the MCP-highlighting README/pub.dev metadata changes from #45 can be published to pub.dev
- Add CHANGELOG entry

## Test plan
- [ ] `dart pub publish --dry-run` passes after merge