### PR TITLE
Improve DevTools observer and MCP performance

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -8,6 +8,7 @@
     - The Riverpod 2.x/3.x API probe in the observer is cached, so it no longer throws and catches a `NoSuchMethodError` on every event on Riverpod 2.x.
     - The MCP event buffer is now a ring buffer with O(1) eviction (previously each event shifted the whole 1000-entry list once full).
     - DevTools extension: the filtered provider/event lists are memoized per state change instead of being re-filtered and re-sorted on every widget rebuild, and appending an event no longer copies the event list twice.
+    - DevTools extension: "Used By" is now answered from a reverse-dependency index rebuilt only when the provider map changes (previously a full providers × dependencies scan on every detail-panel rebuild), the "Last Update" section reads the provider's latest event in O(1) instead of filtering the whole event log, and event de-duplication no longer schedules a Timer per incoming event.
 - **Fixes**:
     - `AsyncValue` states (`data`/`loading`/`error`) are shown again in the extension UI — the `asyncState` marker was unreachable in serialization because the structured `toString()` parser returned first.
     - DevTools extension: the Event Log "Clear All" button now actually clears the log (it was a no-op).

--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+- **MCP**:
+    - `get_riverpod_logs` now accepts optional `limit` (most recent N events) and `provider` (exact provider name) parameters, so AI tools can fetch only the relevant slice of the buffer instead of up to 1000 full events. The local HTTP endpoint (`GET /logs`) accepts the same values as query parameters.
+- **Performance**:
+    - `RiverpodDevToolsObserver` is now near-zero overhead when nothing can consume its events (release/profile builds without a DevTools client attached): value serialization is skipped entirely instead of running on every provider change.
+    - Value serialization uses identity-based cycle detection, avoiding deep user-defined `==`/`hashCode` calls (e.g. freezed models with large collections) on every event, and no longer builds an object's `toString()` when it serializes via `toJson()`.
+    - The Riverpod 2.x/3.x API probe in the observer is cached, so it no longer throws and catches a `NoSuchMethodError` on every event on Riverpod 2.x.
+    - The MCP event buffer is now a ring buffer with O(1) eviction (previously each event shifted the whole 1000-entry list once full).
+    - DevTools extension: the filtered provider/event lists are memoized per state change instead of being re-filtered and re-sorted on every widget rebuild, and appending an event no longer copies the event list twice.
 - **Fixes**:
     - `AsyncValue` states (`data`/`loading`/`error`) are shown again in the extension UI — the `asyncState` marker was unreachable in serialization because the structured `toString()` parser returned first.
     - DevTools extension: the Event Log "Clear All" button now actually clears the log (it was a no-op).

--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -7,6 +7,7 @@
     - Value serialization uses identity-based cycle detection, avoiding deep user-defined `==`/`hashCode` calls (e.g. freezed models with large collections) on every event, and no longer builds an object's `toString()` when it serializes via `toJson()`.
     - The Riverpod 2.x/3.x API probe in the observer is cached, so it no longer throws and catches a `NoSuchMethodError` on every event on Riverpod 2.x.
     - The MCP event buffer is now a ring buffer with O(1) eviction (previously each event shifted the whole 1000-entry list once full).
+    - Static dependency names are cached per provider in the registry instead of being rebuilt from metadata on every provider event.
     - DevTools extension: the filtered provider/event lists are memoized per state change instead of being re-filtered and re-sorted on every widget rebuild, and appending an event no longer copies the event list twice.
     - DevTools extension: "Used By" is now answered from a reverse-dependency index rebuilt only when the provider map changes (previously a full providers × dependencies scan on every detail-panel rebuild), the "Last Update" section reads the provider's latest event in O(1) instead of filtering the whole event log, and event de-duplication no longer schedules a Timer per incoming event.
 - **Fixes**:

--- a/packages/riverpod_devtools/MCP.md
+++ b/packages/riverpod_devtools/MCP.md
@@ -54,7 +54,7 @@ The `get_riverpod_logs` tool is now available and Claude Code will call it autom
 
 | Tool | Description |
 |---|---|
-| `get_riverpod_logs` | Returns buffered provider lifecycle events (`provider_added`, `provider_updated`, `provider_disposed`) as JSON. Not a general app log — Riverpod state changes only. |
+| `get_riverpod_logs` | Returns buffered provider lifecycle events (`provider_added`, `provider_updated`, `provider_disposed`) as JSON. Not a general app log — Riverpod state changes only. Optional parameters: `limit` (return only the most recent N events) and `provider` (return only events for the provider with this exact name). Use them to keep responses small — the buffer holds up to 1000 events. |
 | `clear_riverpod_logs` | Clears the event buffer. |
 
 ## Requirements & limitations

--- a/packages/riverpod_devtools/lib/src/http_server_io.dart
+++ b/packages/riverpod_devtools/lib/src/http_server_io.dart
@@ -1,3 +1,4 @@
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:developer' as developer;
 import 'dart:io';
@@ -9,7 +10,10 @@ class RiverpodDevToolsHttpServer {
     : _maxBufferSize = maxBufferSize;
 
   final int _maxBufferSize;
-  final List<Map<String, Object?>> _buffer = [];
+  // ListQueue gives O(1) eviction at the front; a plain List would shift
+  // every remaining element on each removeAt(0) once the buffer is full,
+  // which runs on every provider event in the observed app.
+  final ListQueue<Map<String, Object?>> _buffer = ListQueue();
   HttpServer? _server;
 
   Future<void> start() async {
@@ -44,7 +48,7 @@ class RiverpodDevToolsHttpServer {
 
   void addEvent(Map<String, Object?> event) {
     if (_buffer.length >= _maxBufferSize) {
-      _buffer.removeAt(0);
+      _buffer.removeFirst();
     }
     _buffer.add(event);
   }
@@ -53,10 +57,30 @@ class RiverpodDevToolsHttpServer {
     _buffer.clear();
   }
 
+  /// Returns buffered events, optionally filtered by provider name and
+  /// truncated to the most recent [limit] entries (chronological order is
+  /// preserved).
+  List<Map<String, Object?>> eventsFor({String? provider, int? limit}) {
+    Iterable<Map<String, Object?>> events = _buffer;
+    if (provider != null && provider.isNotEmpty) {
+      events = events.where((event) => event['provider'] == provider);
+    }
+    final list = events.toList(growable: false);
+    if (limit != null && limit >= 0 && list.length > limit) {
+      return list.sublist(list.length - limit);
+    }
+    return list;
+  }
+
   Future<void> _handleRequest(HttpRequest request) async {
     try {
       if (request.method == 'GET' && request.uri.path == '/logs') {
-        final json = jsonEncode(_buffer, toEncodable: (obj) => obj.toString());
+        final params = request.uri.queryParameters;
+        final events = eventsFor(
+          provider: params['provider'],
+          limit: int.tryParse(params['limit'] ?? ''),
+        );
+        final json = jsonEncode(events, toEncodable: (obj) => obj.toString());
         request.response
           ..statusCode = 200
           ..headers.contentType = ContentType.json

--- a/packages/riverpod_devtools/lib/src/http_server_io.dart
+++ b/packages/riverpod_devtools/lib/src/http_server_io.dart
@@ -59,27 +59,46 @@ class RiverpodDevToolsHttpServer {
 
   /// Returns buffered events, optionally filtered by provider name and
   /// truncated to the most recent [limit] entries (chronological order is
-  /// preserved).
+  /// preserved). A negative [limit] is treated as 0 (empty result).
   List<Map<String, Object?>> eventsFor({String? provider, int? limit}) {
-    Iterable<Map<String, Object?>> events = _buffer;
+    if (limit != null && limit < 0) limit = 0;
     if (provider != null && provider.isNotEmpty) {
-      events = events.where((event) => event['provider'] == provider);
-    }
-    final list = events.toList(growable: false);
-    if (limit != null && limit >= 0 && list.length > limit) {
+      final list = _buffer
+          .where((event) => event['provider'] == provider)
+          .toList(growable: false);
+      if (limit == null || list.length <= limit) return list;
       return list.sublist(list.length - limit);
     }
-    return list;
+    // No filter: take the tail directly so only `limit` elements are ever
+    // materialized instead of copying the whole buffer first.
+    if (limit == null || _buffer.length <= limit) {
+      return _buffer.toList(growable: false);
+    }
+    return _buffer.skip(_buffer.length - limit).toList(growable: false);
   }
 
   Future<void> _handleRequest(HttpRequest request) async {
     try {
       if (request.method == 'GET' && request.uri.path == '/logs') {
         final params = request.uri.queryParameters;
-        final events = eventsFor(
-          provider: params['provider'],
-          limit: int.tryParse(params['limit'] ?? ''),
-        );
+
+        int? limit;
+        final rawLimit = params['limit'];
+        if (rawLimit != null) {
+          // Accept "50" and "50.0" (some clients format integers as
+          // doubles); reject anything else explicitly instead of silently
+          // returning the full buffer.
+          limit = int.tryParse(rawLimit) ?? num.tryParse(rawLimit)?.toInt();
+          if (limit == null || limit < 0) {
+            request.response
+              ..statusCode = 400
+              ..write('Invalid "limit": expected a non-negative integer.');
+            await request.response.close();
+            return;
+          }
+        }
+
+        final events = eventsFor(provider: params['provider'], limit: limit);
         final json = jsonEncode(events, toEncodable: (obj) => obj.toString());
         request.response
           ..statusCode = 200

--- a/packages/riverpod_devtools/lib/src/http_server_stub.dart
+++ b/packages/riverpod_devtools/lib/src/http_server_stub.dart
@@ -4,4 +4,6 @@ class RiverpodDevToolsHttpServer {
   void stop() {}
   void addEvent(Map<String, Object?> event) {}
   void clearEvents() {}
+  List<Map<String, Object?>> eventsFor({String? provider, int? limit}) =>
+      const [];
 }

--- a/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
@@ -63,7 +63,10 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
   FutureOr<CallToolResult> _getRiverpodLogs(CallToolRequest request) async {
     final arguments = request.arguments ?? const {};
     final queryParameters = <String, String>{
-      // Some MCP clients send integers as JSON doubles (e.g. 50.0).
+      // dart_mcp validates arguments against the schema before this runs,
+      // rejecting strings and fractional numbers — but whole doubles
+      // (e.g. 50.0, as some clients encode integers) pass validation and
+      // arrive here as num, so normalize via toInt().
       if (arguments['limit'] case final num limit) 'limit': '${limit.toInt()}',
       if (arguments['provider'] case final String provider
           when provider.isNotEmpty)

--- a/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
@@ -30,8 +30,25 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
         '(previous/new value diff), and provider_disposed. '
         'Use this when investigating Riverpod state bugs, unexpected re-builds, '
         'or provider lifecycle issues. '
+        'The buffer can hold up to 1000 events; prefer passing "limit" (and '
+        '"provider" when you know which provider you are investigating) to '
+        'keep the response small. '
         'Requires the app to be running in debug mode (flutter run).',
-    inputSchema: Schema.object(properties: {}),
+    inputSchema: Schema.object(
+      properties: {
+        'limit': Schema.int(
+          description:
+              'Return only the most recent N events (after applying the '
+              'provider filter). Omit to return the full buffer.',
+          minimum: 1,
+        ),
+        'provider': Schema.string(
+          description:
+              'Return only events for the provider with this exact name '
+              '(e.g. "counterProvider").',
+        ),
+      },
+    ),
   );
 
   final _clearRiverpodLogsTool = Tool(
@@ -44,9 +61,18 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
   );
 
   FutureOr<CallToolResult> _getRiverpodLogs(CallToolRequest request) async {
+    final arguments = request.arguments ?? const {};
+    final queryParameters = <String, String>{
+      // Some MCP clients send integers as JSON doubles (e.g. 50.0).
+      if (arguments['limit'] case final num limit) 'limit': '${limit.toInt()}',
+      if (arguments['provider'] case final String provider
+          when provider.isNotEmpty)
+        'provider': provider,
+    };
     return _request(
       'GET',
       '/logs',
+      queryParameters: queryParameters,
       (body) => CallToolResult(content: [TextContent(text: body)]),
     );
   }
@@ -63,15 +89,23 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
   Future<CallToolResult> _request(
     String method,
     String path,
-    CallToolResult Function(String body) onSuccess,
-  ) async {
+    CallToolResult Function(String body) onSuccess, {
+    Map<String, String> queryParameters = const {},
+  }) async {
     try {
       final client = io.HttpClient();
       try {
         final req = await client
             .openUrl(
               method,
-              Uri.parse('http://localhost:$riverpodDevToolsMcpPort$path'),
+              Uri(
+                scheme: 'http',
+                host: 'localhost',
+                port: riverpodDevToolsMcpPort,
+                path: path,
+                queryParameters:
+                    queryParameters.isEmpty ? null : queryParameters,
+              ),
             )
             .timeout(const Duration(seconds: 5));
         final response = await req.close();

--- a/packages/riverpod_devtools/lib/src/observer.dart
+++ b/packages/riverpod_devtools/lib/src/observer.dart
@@ -47,12 +47,22 @@ final class RiverpodDevToolsObserver extends ProviderObserver {
 
   final RiverpodDevToolsHttpServer _httpServer;
 
+  /// Whether any consumer can observe events right now.
+  ///
+  /// In debug mode the local HTTP buffer (MCP) always needs events. Outside
+  /// debug mode, events only matter when a DevTools client is listening on
+  /// the Extension stream — otherwise `developer.postEvent` drops them, so
+  /// serializing values would be pure overhead on every provider change.
+  bool get _hasConsumer =>
+      kDebugMode || developer.extensionStreamHasListener;
+
   @override
   void didAddProvider(
     covariant Object context,
     Object? value, [
     covariant Object? arg3, // Container in Riverpod 2.x, unused in 3.0
   ]) {
+    if (!_hasConsumer) return;
     final provider = _getProvider(context);
     final providerName = _getProviderName(provider);
 
@@ -69,6 +79,7 @@ final class RiverpodDevToolsObserver extends ProviderObserver {
     Object? newValue, [
     covariant Object? arg4, // Container in Riverpod 2.x, unused in 3.0
   ]) {
+    if (!_hasConsumer) return;
     final provider = _getProvider(context);
     final providerName = _getProviderName(provider);
 
@@ -84,6 +95,7 @@ final class RiverpodDevToolsObserver extends ProviderObserver {
     covariant Object context, [
     covariant Object? arg2, // Container in Riverpod 2.x, unused in 3.0
   ]) {
+    if (!_hasConsumer) return;
     final provider = _getProvider(context);
     final providerName = _getProviderName(provider);
 
@@ -92,17 +104,26 @@ final class RiverpodDevToolsObserver extends ProviderObserver {
     });
   }
 
+  /// Caches the API probe result: true once `context.provider` has succeeded
+  /// (Riverpod 3.0), false once it has thrown (Riverpod 2.x). The Riverpod
+  /// version cannot change at runtime, so probing (and throwing/catching
+  /// NoSuchMethodError) on every single event is wasted work.
+  bool? _contextHasProviderProperty;
+
   /// Extracts the provider from either ProviderObserverContext (3.0) or ProviderBase (2.x)
   dynamic _getProvider(Object arg) {
     // In Riverpod 3.0, arg is ProviderObserverContext which has a 'provider' property.
     // In Riverpod 2.x, arg is directly ProviderBase.
-    // We probe for the 'provider' property.
+    if (_contextHasProviderProperty == false) return arg;
     try {
       final dynamic context = arg;
       // ignore: avoid_dynamic_calls
-      return context.provider;
+      final provider = context.provider;
+      _contextHasProviderProperty = true;
+      return provider;
     } on NoSuchMethodError {
       // If 'provider' property doesn't exist, it's likely the 2.x API where arg is the provider itself.
+      _contextHasProviderProperty = false;
       return arg;
     } catch (_) {
       // Fallback for other errors

--- a/packages/riverpod_devtools/lib/src/static_dependencies.dart
+++ b/packages/riverpod_devtools/lib/src/static_dependencies.dart
@@ -117,6 +117,11 @@ class RiverpodDevToolsRegistry {
   /// Internal storage of provider metadata
   final Map<String, StaticProviderMetadata> _metadata = {};
 
+  /// Dependency-name lists derived from [_metadata], cached because the
+  /// observer asks for them on every single provider event. Entries are
+  /// unmodifiable since they are shared across events.
+  final Map<String, List<String>> _dependencyNamesCache = {};
+
   /// Timestamp when the JSON was last loaded (app startup time)
   DateTime? _lastLoadedTimestamp;
 
@@ -128,6 +133,7 @@ class RiverpodDevToolsRegistry {
   /// This is typically called by generated code, not by user code.
   void register(StaticProviderMetadata metadata) {
     _metadata[metadata.name] = metadata;
+    _dependencyNamesCache.remove(metadata.name);
   }
 
   /// Get full metadata for a provider
@@ -141,7 +147,14 @@ class RiverpodDevToolsRegistry {
   ///
   /// Returns an empty list if no static metadata is available.
   List<String> getDependencyNames(String providerName) {
-    return _metadata[providerName]?.dependencies.map((dep) => dep.providerName).toList() ?? [];
+    final cached = _dependencyNamesCache[providerName];
+    if (cached != null) return cached;
+
+    final metadata = _metadata[providerName];
+    if (metadata == null) return const [];
+    return _dependencyNamesCache[providerName] = List.unmodifiable(
+      metadata.dependencies.map((dep) => dep.providerName),
+    );
   }
 
   /// Get dependencies with full details (type, source location) as JSON
@@ -164,6 +177,7 @@ class RiverpodDevToolsRegistry {
   /// Primarily used for testing.
   void clear() {
     _metadata.clear();
+    _dependencyNamesCache.clear();
   }
 
   /// Get the total number of registered providers

--- a/packages/riverpod_devtools/lib/src/utils/serialization.dart
+++ b/packages/riverpod_devtools/lib/src/utils/serialization.dart
@@ -13,8 +13,10 @@ Map<String, Object?> serializeValue(
     };
   }
 
-  // Cycle detection
-  visited ??= {};
+  // Cycle detection. Identity-based on purpose: cycles are a property of the
+  // object graph, and identity checks avoid invoking potentially deep (or
+  // even cyclic) user-defined ==/hashCode implementations on every event.
+  visited ??= Set<Object>.identity();
   // Primitives and strings are safe, no need to track
   if (value is! num && value is! bool && value is! String) {
     if (visited.contains(value)) {
@@ -34,16 +36,15 @@ Map<String, Object?> serializeValue(
     };
   }
 
-  // Capture toString() early
-  final stringValue = value.toString();
-
   // Helper to continue serialization
   Map<String, Object?> recurse(Object? val) {
     return serializeValue(val, depth: depth + 1, visited: visited);
   }
 
   try {
-    // Check if the object has a toJson() method first (most specific)
+    // Check if the object has a toJson() method first (most specific).
+    // Do this before computing toString() so objects that serialize via
+    // toJson() never pay for building their (possibly large) string form.
     try {
       final dynamic obj = value;
       // ignore: avoid_dynamic_calls
@@ -65,6 +66,8 @@ Map<String, Object?> serializeValue(
     } catch (_) {
       // toJson() doesn't exist or failed
     }
+
+    final stringValue = value.toString();
 
     // Try to extract useful information based on type
     final Map<String, Object?> result = {

--- a/packages/riverpod_devtools/lib/src/utils/serialization.dart
+++ b/packages/riverpod_devtools/lib/src/utils/serialization.dart
@@ -53,14 +53,13 @@ Map<String, Object?> serializeValue(
       // Avoid re-encoding unless we need to ensure it's pure JSON safe,
       // but typically we can trust toJson or handle the result recursively.
       if (json is Map || json is List) {
-        // We wrap the result in our structure, but we might want to recurse
-        // if the toJson result contains non-primitive objects.
-        // For simplicity and safety, let's treat the result as a value to serialize
-        // but reset depth since it's a new representation?
-        // Actually, let's just use it.
+        // Sanitize the result: toJson() implementations may nest values that
+        // json.encode can't handle (DateTime, enums, custom objects), and
+        // developer.postEvent encodes the event without a toEncodable
+        // fallback — an unencodable leaf would make the whole event throw.
         return {
           'type': value.runtimeType.toString(),
-          'value': json,
+          'value': _jsonSafe(json, 0),
         };
       }
     } catch (_) {
@@ -124,6 +123,26 @@ Map<String, Object?> serializeValue(
       visited.remove(value);
     }
   }
+}
+
+/// Deep-copies a toJson() result, converting any leaf that json.encode
+/// cannot handle (DateTime, enums, custom objects) to its toString() form.
+Object? _jsonSafe(Object? value, int depth) {
+  const maxDepth = 10;
+  if (value == null || value is num || value is bool || value is String) {
+    return value;
+  }
+  if (depth > maxDepth) return value.toString();
+  if (value is Map) {
+    return {
+      for (final entry in value.entries)
+        entry.key.toString(): _jsonSafe(entry.value, depth + 1),
+    };
+  }
+  if (value is List) {
+    return [for (final item in value) _jsonSafe(item, depth + 1)];
+  }
+  return value.toString();
 }
 
 /// Parses a string representation of an object (e.g., from toString())

--- a/packages/riverpod_devtools/test/http_server_test.dart
+++ b/packages/riverpod_devtools/test/http_server_test.dart
@@ -57,6 +57,17 @@ void main() {
       expect(events.map((e) => e['newValue']), [6, 8]);
     });
 
+    test('eventsFor treats limit 0 and negative limits as empty', () {
+      final server = RiverpodDevToolsHttpServer();
+      for (var i = 0; i < 3; i++) {
+        server.addEvent(event('a', i));
+      }
+
+      expect(server.eventsFor(limit: 0), isEmpty);
+      expect(server.eventsFor(limit: -1), isEmpty);
+      expect(server.eventsFor(provider: 'a', limit: 0), isEmpty);
+    });
+
     test('eventsFor with a limit larger than the buffer returns everything',
         () {
       final server = RiverpodDevToolsHttpServer();

--- a/packages/riverpod_devtools/test/http_server_test.dart
+++ b/packages/riverpod_devtools/test/http_server_test.dart
@@ -1,0 +1,76 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_devtools/src/http_server_io.dart';
+
+void main() {
+  group('RiverpodDevToolsHttpServer event buffer', () {
+    Map<String, Object?> event(String provider, int i) => {
+          'type': 'provider_updated',
+          'provider': provider,
+          'newValue': i,
+        };
+
+    test('evicts oldest events once maxBufferSize is reached', () {
+      final server = RiverpodDevToolsHttpServer(maxBufferSize: 3);
+      for (var i = 0; i < 5; i++) {
+        server.addEvent(event('a', i));
+      }
+
+      final events = server.eventsFor();
+      expect(events.map((e) => e['newValue']), [2, 3, 4]);
+    });
+
+    test('eventsFor returns all events by default', () {
+      final server = RiverpodDevToolsHttpServer();
+      server.addEvent(event('a', 0));
+      server.addEvent(event('b', 1));
+
+      expect(server.eventsFor().length, 2);
+    });
+
+    test('eventsFor filters by provider name', () {
+      final server = RiverpodDevToolsHttpServer();
+      server.addEvent(event('a', 0));
+      server.addEvent(event('b', 1));
+      server.addEvent(event('a', 2));
+
+      final events = server.eventsFor(provider: 'a');
+      expect(events.map((e) => e['newValue']), [0, 2]);
+    });
+
+    test('eventsFor keeps the most recent events when limited', () {
+      final server = RiverpodDevToolsHttpServer();
+      for (var i = 0; i < 10; i++) {
+        server.addEvent(event('a', i));
+      }
+
+      final events = server.eventsFor(limit: 3);
+      expect(events.map((e) => e['newValue']), [7, 8, 9]);
+    });
+
+    test('eventsFor applies the provider filter before the limit', () {
+      final server = RiverpodDevToolsHttpServer();
+      for (var i = 0; i < 10; i++) {
+        server.addEvent(event(i.isEven ? 'a' : 'b', i));
+      }
+
+      final events = server.eventsFor(provider: 'a', limit: 2);
+      expect(events.map((e) => e['newValue']), [6, 8]);
+    });
+
+    test('eventsFor with a limit larger than the buffer returns everything',
+        () {
+      final server = RiverpodDevToolsHttpServer();
+      server.addEvent(event('a', 0));
+
+      expect(server.eventsFor(limit: 100).length, 1);
+    });
+
+    test('clearEvents empties the buffer', () {
+      final server = RiverpodDevToolsHttpServer();
+      server.addEvent(event('a', 0));
+      server.clearEvents();
+
+      expect(server.eventsFor(), isEmpty);
+    });
+  });
+}

--- a/packages/riverpod_devtools/test/serialization_test.dart
+++ b/packages/riverpod_devtools/test/serialization_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:riverpod_devtools/src/utils/serialization.dart';
 
@@ -26,6 +28,18 @@ class FakeAsyncError {
   @override
   String toString() =>
       'AsyncError<int>(error: Exception: boom, stackTrace: #0 main)';
+}
+
+/// A model whose toJson() contains values json.encode can't handle directly.
+class ModelWithUnsafeToJson {
+  Map<String, Object?> toJson() => {
+        'name': 'test',
+        'createdAt': DateTime.utc(2026, 1, 1),
+        'nested': [
+          DateTime.utc(2026, 1, 2),
+          {'inner': DateTime.utc(2026, 1, 3)},
+        ],
+      };
 }
 
 void main() {
@@ -92,6 +106,20 @@ void main() {
 
       final error = serializeValue(FakeAsyncError());
       expect(error['asyncState'], 'error');
+    });
+
+    test('sanitizes non-JSON-encodable leaves in toJson() output', () {
+      final result = serializeValue(ModelWithUnsafeToJson());
+      final value = result['value'] as Map;
+
+      expect(value['name'], 'test');
+      expect(value['createdAt'], isA<String>());
+      final nested = value['nested'] as List;
+      expect(nested[0], isA<String>());
+      expect((nested[1] as Map)['inner'], isA<String>());
+      // The whole event must survive json.encode without a toEncodable
+      // fallback, as developer.postEvent has none.
+      expect(() => jsonEncode(result), returnsNormally);
     });
 
     test('handles circular references', () {

--- a/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
+++ b/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
@@ -279,6 +279,11 @@ class InspectorNotifier extends ChangeNotifier {
     if (rawValue == null) {
       return {'type': 'null', 'value': null};
     }
+    if (rawValue is Map<String, dynamic>) {
+      // Already the right type (the common case for decoded event JSON):
+      // it is treated as read-only downstream, so skip the copy.
+      return rawValue;
+    }
     if (rawValue is Map) {
       return Map<String, dynamic>.from(rawValue);
     }

--- a/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
+++ b/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
@@ -68,6 +68,20 @@ class InspectorNotifier extends ChangeNotifier {
 
   InspectorState get state => _state;
 
+  // Memoized derived lists. Panels read [filteredProviders]/[filteredEvents]
+  // on every rebuild (which happens on every provider event), so recomputing
+  // the filter + merge/sort each time is wasted work. Every state mutation
+  // ends with [notifyListeners], which invalidates both caches.
+  List<ProviderInfo>? _filteredProvidersCache;
+  List<ProviderEvent>? _filteredEventsCache;
+
+  @override
+  void notifyListeners() {
+    _filteredProvidersCache = null;
+    _filteredEventsCache = null;
+    super.notifyListeners();
+  }
+
   static const int _maxEventCount = 1000;
   static const int _maxDisposedProviders = 100;
 
@@ -185,7 +199,10 @@ class InspectorNotifier extends ChangeNotifier {
     }
   }
 
-  List<ProviderInfo> get filteredProviders {
+  List<ProviderInfo> get filteredProviders =>
+      _filteredProvidersCache ??= _computeFilteredProviders();
+
+  List<ProviderInfo> _computeFilteredProviders() {
     final providers = _state.providers.values.toList();
     if (_state.providerSearchQuery.isEmpty) return providers;
 
@@ -195,7 +212,10 @@ class InspectorNotifier extends ChangeNotifier {
         .toList();
   }
 
-  List<ProviderEvent> get filteredEvents {
+  List<ProviderEvent> get filteredEvents =>
+      _filteredEventsCache ??= _computeFilteredEvents();
+
+  List<ProviderEvent> _computeFilteredEvents() {
     if (_state.selectedProviderNames.isEmpty) return _state.events;
 
     final allEvents = <ProviderEvent>[];
@@ -373,32 +393,35 @@ class InspectorNotifier extends ChangeNotifier {
         _eventsByProvider.putIfAbsent(newEvent.providerName, () => []);
         _eventsByProvider[newEvent.providerName]!.insert(0, newEvent);
 
-        _state = _state.copyWith(providers: newProviders, events: newEvents);
-        _applyRingBuffer();
+        // Ring buffer: evict the oldest event in place, on the copy we just
+        // made, instead of copying the whole list a second time.
+        Set<String>? newExpanded;
+        while (newEvents.length > _maxEventCount) {
+          final removed = newEvents.removeLast();
+
+          final providerEvents = _eventsByProvider[removed.providerName];
+          if (providerEvents != null) {
+            providerEvents.remove(removed);
+            if (providerEvents.isEmpty) {
+              _eventsByProvider.remove(removed.providerName);
+            }
+          }
+
+          if (_state.expandedEventIds.contains(removed.id)) {
+            newExpanded ??= Set<String>.from(_state.expandedEventIds);
+            newExpanded.remove(removed.id);
+          }
+        }
+
+        _state = _state.copyWith(
+          providers: newProviders,
+          events: newEvents,
+          expandedEventIds: newExpanded,
+        );
         _cleanupDisposedProviders();
         notifyListeners();
       }
     });
-  }
-
-  void _applyRingBuffer() {
-    if (_state.events.length > _maxEventCount) {
-      final newEvents = List<ProviderEvent>.from(_state.events);
-      final removed = newEvents.removeAt(_maxEventCount);
-
-      final providerEvents = _eventsByProvider[removed.providerName];
-      if (providerEvents != null) {
-        providerEvents.remove(removed);
-        if (providerEvents.isEmpty) {
-          _eventsByProvider.remove(removed.providerName);
-        }
-      }
-
-      final newExpanded = Set<String>.from(_state.expandedEventIds)
-        ..remove(removed.id);
-      _state =
-          _state.copyWith(events: newEvents, expandedEventIds: newExpanded);
-    }
   }
 
   void _cleanupDisposedProviders() {

--- a/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
+++ b/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
@@ -75,12 +75,15 @@ class InspectorNotifier extends ChangeNotifier {
   // changed — e.g. flash-animation ticks touch neither cache.
   List<ProviderInfo>? _filteredProvidersCache;
   List<ProviderEvent>? _filteredEventsCache;
+  Map<String, List<String>>? _usedByIndex;
 
   void _setState(InspectorState newState) {
     final old = _state;
     _state = newState;
-    if (!identical(old.providers, newState.providers) ||
-        old.providerSearchQuery != newState.providerSearchQuery) {
+    if (!identical(old.providers, newState.providers)) {
+      _filteredProvidersCache = null;
+      _usedByIndex = null;
+    } else if (old.providerSearchQuery != newState.providerSearchQuery) {
       _filteredProvidersCache = null;
     }
     if (!identical(old.events, newState.events) ||
@@ -92,10 +95,17 @@ class InspectorNotifier extends ChangeNotifier {
 
   static const int _maxEventCount = 1000;
   static const int _maxDisposedProviders = 100;
+  static const int _dedupWindowMs = 100;
+  static const int _dedupPruneThreshold = 64;
 
   final Map<String, DateTime> _disposedProviderTimestamps = {};
   final Map<String, List<ProviderEvent>> _eventsByProvider = {};
-  final Set<String> _processedEventKeys = {};
+
+  /// Recently seen event keys mapped to their dedup-window expiry, in
+  /// milliseconds since epoch. Expired entries are pruned in bulk once the
+  /// map grows past [_dedupPruneThreshold] — cheaper than the previous
+  /// approach of scheduling a 100ms Timer per event.
+  final Map<String, int> _processedEventKeys = {};
   StreamSubscription? _extensionSubscription;
   Timer? _flashTimer;
 
@@ -237,14 +247,32 @@ class InspectorNotifier extends ChangeNotifier {
     return allEvents;
   }
 
-  List<String> getUsedBy(String providerName) {
-    final usedBy = <String>[];
+  /// Providers that depend on [providerName], from a reverse-dependency
+  /// index that is rebuilt only when the provider map changes (the naive
+  /// scan was O(providers × dependencies) on every detail-panel rebuild).
+  List<String> getUsedBy(String providerName) =>
+      (_usedByIndex ??= _computeUsedByIndex())[providerName] ?? const [];
+
+  Map<String, List<String>> _computeUsedByIndex() {
+    final index = <String, List<String>>{};
     for (final entry in _state.providers.entries) {
-      if (entry.value.dependencies.contains(providerName)) {
-        usedBy.add(entry.key);
+      for (final dependency in entry.value.dependencies) {
+        final dependents = index[dependency] ??= [];
+        // A provider may list the same dependency several times (e.g. watch
+        // + read of the same provider); additions for one provider are
+        // contiguous, so checking the last element is enough to dedupe.
+        if (dependents.isEmpty || dependents.last != entry.key) {
+          dependents.add(entry.key);
+        }
       }
     }
-    return usedBy;
+    return index;
+  }
+
+  /// The most recent event for [providerName], if any (O(1) lookup).
+  ProviderEvent? latestEventFor(String providerName) {
+    final events = _eventsByProvider[providerName];
+    return events == null || events.isEmpty ? null : events.first;
   }
 
   Map<String, dynamic> _normalizeValue(dynamic rawValue) {
@@ -321,10 +349,13 @@ class InspectorNotifier extends ChangeNotifier {
               : value.toString());
       final eventKey = '$kind:$providerId:$valueString';
 
-      if (_processedEventKeys.contains(eventKey)) return;
-      _processedEventKeys.add(eventKey);
-      Timer(const Duration(milliseconds: 100),
-          () => _processedEventKeys.remove(eventKey));
+      final nowMs = DateTime.now().millisecondsSinceEpoch;
+      final dedupExpiry = _processedEventKeys[eventKey];
+      if (dedupExpiry != null && nowMs < dedupExpiry) return;
+      if (_processedEventKeys.length >= _dedupPruneThreshold) {
+        _processedEventKeys.removeWhere((_, expiry) => expiry <= nowMs);
+      }
+      _processedEventKeys[eventKey] = nowMs + _dedupWindowMs;
 
       final eventTimestamp = timestamp != null
           ? DateTime.fromMillisecondsSinceEpoch(timestamp)

--- a/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
+++ b/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
@@ -70,16 +70,24 @@ class InspectorNotifier extends ChangeNotifier {
 
   // Memoized derived lists. Panels read [filteredProviders]/[filteredEvents]
   // on every rebuild (which happens on every provider event), so recomputing
-  // the filter + merge/sort each time is wasted work. Every state mutation
-  // ends with [notifyListeners], which invalidates both caches.
+  // the filter + merge/sort each time is wasted work. All state mutations go
+  // through [_setState], which invalidates exactly the caches whose inputs
+  // changed — e.g. flash-animation ticks touch neither cache.
   List<ProviderInfo>? _filteredProvidersCache;
   List<ProviderEvent>? _filteredEventsCache;
 
-  @override
-  void notifyListeners() {
-    _filteredProvidersCache = null;
-    _filteredEventsCache = null;
-    super.notifyListeners();
+  void _setState(InspectorState newState) {
+    final old = _state;
+    _state = newState;
+    if (!identical(old.providers, newState.providers) ||
+        old.providerSearchQuery != newState.providerSearchQuery) {
+      _filteredProvidersCache = null;
+    }
+    if (!identical(old.events, newState.events) ||
+        !identical(
+            old.selectedProviderNames, newState.selectedProviderNames)) {
+      _filteredEventsCache = null;
+    }
   }
 
   static const int _maxEventCount = 1000;
@@ -105,17 +113,17 @@ class InspectorNotifier extends ChangeNotifier {
   }
 
   void updateSearchQuery(String query) {
-    _state = _state.copyWith(providerSearchQuery: query);
+    _setState(_state.copyWith(providerSearchQuery: query));
     notifyListeners();
   }
 
   void clearEvents() {
     _eventsByProvider.clear();
     _processedEventKeys.clear();
-    _state = _state.copyWith(
+    _setState(_state.copyWith(
       events: const [],
       expandedEventIds: const {},
-    );
+    ));
     notifyListeners();
   }
 
@@ -126,17 +134,17 @@ class InspectorNotifier extends ChangeNotifier {
     } else {
       newExpanded.add(eventId);
     }
-    _state = _state.copyWith(expandedEventIds: newExpanded);
+    _setState(_state.copyWith(expandedEventIds: newExpanded));
     notifyListeners();
   }
 
   void selectProvider(String providerName) {
     final newSelected = Set<String>.from(_state.selectedProviderNames);
     newSelected.add(providerName);
-    _state = _state.copyWith(
+    _setState(_state.copyWith(
       selectedProviderNames: newSelected,
       activeTabProviderName: providerName,
-    );
+    ));
     notifyListeners();
   }
 
@@ -149,49 +157,49 @@ class InspectorNotifier extends ChangeNotifier {
       newActiveTab = newSelected.isNotEmpty ? newSelected.first : null;
     }
 
-    _state = _state.copyWith(
+    _setState(_state.copyWith(
       selectedProviderNames: newSelected,
       activeTabProviderName: newActiveTab,
-    );
+    ));
     notifyListeners();
   }
 
   void setActiveTab(String providerName) {
-    _state = _state.copyWith(activeTabProviderName: providerName);
+    _setState(_state.copyWith(activeTabProviderName: providerName));
     notifyListeners();
   }
 
   void updateLeftSplitRatio(double ratio) {
-    _state = _state.copyWith(leftSplitRatio: ratio);
+    _setState(_state.copyWith(leftSplitRatio: ratio));
     notifyListeners();
   }
 
   void updateRightSplitRatio(double ratio) {
-    _state = _state.copyWith(rightSplitRatio: ratio);
+    _setState(_state.copyWith(rightSplitRatio: ratio));
     notifyListeners();
   }
 
   void flashProvider(String providerName, {int flashCount = 2}) {
     _flashTimer?.cancel();
-    _state = _state.copyWith(flashingProviderName: providerName);
+    _setState(_state.copyWith(flashingProviderName: providerName));
     notifyListeners();
 
     if (flashCount == 1) {
       _flashTimer = Timer(const Duration(milliseconds: 300), () {
-        _state = _state.copyWith(flashingProviderName: null);
+        _setState(_state.copyWith(flashingProviderName: null));
         notifyListeners();
       });
     } else {
       _flashTimer = Timer(const Duration(milliseconds: 200), () {
-        _state = _state.copyWith(flashingProviderName: null);
+        _setState(_state.copyWith(flashingProviderName: null));
         notifyListeners();
 
         _flashTimer = Timer(const Duration(milliseconds: 100), () {
-          _state = _state.copyWith(flashingProviderName: providerName);
+          _setState(_state.copyWith(flashingProviderName: providerName));
           notifyListeners();
 
           _flashTimer = Timer(const Duration(milliseconds: 200), () {
-            _state = _state.copyWith(flashingProviderName: null);
+            _setState(_state.copyWith(flashingProviderName: null));
             notifyListeners();
           });
         });
@@ -367,16 +375,17 @@ class InspectorNotifier extends ChangeNotifier {
           timestamp: eventTimestamp,
         );
       } else if (kind == 'riverpod:provider_disposed') {
+        final existing = _state.providers[providerName];
         newProviders[providerName] = ProviderInfo(
           id: providerId,
           name: providerName,
-          value: _state.providers[providerName]?.value ??
-              {'type': 'null', 'value': null},
+          value: existing?.value ?? {'type': 'null', 'value': null},
           status: ProviderStatus.disposed,
-          dependencies: _state.providers[providerName]?.dependencies ?? [],
-          dependenciesSource: _state.providers[providerName]?.dependenciesSource ?? DependencySource.none,
-          dependenciesLoadedAt: _state.providers[providerName]?.dependenciesLoadedAt,
-          dependenciesGeneratedAt: _state.providers[providerName]?.dependenciesGeneratedAt,
+          dependencies: existing?.dependencies ?? [],
+          dependenciesSource:
+              existing?.dependenciesSource ?? DependencySource.none,
+          dependenciesLoadedAt: existing?.dependenciesLoadedAt,
+          dependenciesGeneratedAt: existing?.dependenciesGeneratedAt,
         );
         newEvent = ProviderEvent(
           type: EventType.disposed,
@@ -393,10 +402,11 @@ class InspectorNotifier extends ChangeNotifier {
         _eventsByProvider.putIfAbsent(newEvent.providerName, () => []);
         _eventsByProvider[newEvent.providerName]!.insert(0, newEvent);
 
-        // Ring buffer: evict the oldest event in place, on the copy we just
-        // made, instead of copying the whole list a second time.
+        // Ring buffer: exactly one event was inserted, so at most one needs
+        // evicting. Evict in place on the copy we just made instead of
+        // copying the whole list a second time.
         Set<String>? newExpanded;
-        while (newEvents.length > _maxEventCount) {
+        if (newEvents.length > _maxEventCount) {
           final removed = newEvents.removeLast();
 
           final providerEvents = _eventsByProvider[removed.providerName];
@@ -408,16 +418,17 @@ class InspectorNotifier extends ChangeNotifier {
           }
 
           if (_state.expandedEventIds.contains(removed.id)) {
-            newExpanded ??= Set<String>.from(_state.expandedEventIds);
-            newExpanded.remove(removed.id);
+            // Passing null to copyWith below means "keep the current set".
+            newExpanded = Set<String>.from(_state.expandedEventIds)
+              ..remove(removed.id);
           }
         }
 
-        _state = _state.copyWith(
+        _setState(_state.copyWith(
           providers: newProviders,
           events: newEvents,
           expandedEventIds: newExpanded,
-        );
+        ));
         _cleanupDisposedProviders();
         notifyListeners();
       }
@@ -456,12 +467,12 @@ class InspectorNotifier extends ChangeNotifier {
       }
     }
 
-    _state = _state.copyWith(
+    _setState(_state.copyWith(
       providers: newProviders,
       events: newEvents,
       expandedEventIds: newExpanded,
       selectedProviderNames: newSelected,
       activeTabProviderName: newActiveTab,
-    );
+    ));
   }
 }

--- a/packages/riverpod_devtools_extension/lib/src/widgets/detail_panel/detail_panel.dart
+++ b/packages/riverpod_devtools_extension/lib/src/widgets/detail_panel/detail_panel.dart
@@ -278,12 +278,7 @@ class DetailPanel extends StatelessWidget {
   }
 
   Widget _buildLastUpdateSection(ThemeData theme, ProviderInfo provider) {
-    // We need to look at events logic here. It's in the notifier.
-    // For now we'll just implement it similarly.
-    final providerEvents = notifier.filteredEvents
-        .where((e) => e.providerName == provider.name)
-        .toList();
-    final lastEvent = providerEvents.isNotEmpty ? providerEvents.first : null;
+    final lastEvent = notifier.latestEventFor(provider.name);
 
     if (lastEvent == null) {
       return _buildDetailSection(


### PR DESCRIPTION
Observer / serialization (hot path in the observed app):
- Skip event building entirely when nothing can consume events
  (release/profile builds with no DevTools client attached), so the
  observer is near-zero overhead instead of serializing every value.
- Cache the Riverpod 2.x/3.x API probe so a NoSuchMethodError is no
  longer thrown and caught on every event on Riverpod 2.x.
- Use identity-based cycle detection in serializeValue, avoiding deep
  user-defined ==/hashCode calls per event, and skip building
  toString() for objects that serialize via toJson().

MCP / local HTTP server:
- Replace the List buffer with a ListQueue ring buffer (O(1) eviction
  instead of shifting up to 1000 entries per event once full).
- get_riverpod_logs now accepts optional limit and provider parameters
  (GET /logs?limit=&provider=) so AI tools can fetch only the relevant
  slice of the buffer instead of up to 1000 full events per call.

DevTools extension:
- Memoize filteredProviders/filteredEvents so the filter + merge/sort
  no longer reruns on every widget rebuild (they run per state change).
- Evict ring-buffer overflow in place instead of copying the event
  list a second time on every event.

Verified with flutter test (both packages) and end-to-end checks of
GET /logs query parameters and the MCP tool over stdio.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y3pHsEyNNohpVFvVq7277f