### PR TITLE
Fix provider list click reliability and panel header layout

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+- **Extension UI fixes**:
+    - Provider list clicks are reliable again: tiles now use a real tap gesture instead of a raw pointer listener, so the surrounding "tap empty area to deselect" handler no longer fires on every tile click. Previously a selection only survived if the click was released fast enough — slow clicks were silently undone.
+    - Clearing the selection (empty-area tap or the Clear button) is now a single atomic state change instead of one rebuild per selected provider.
+    - The dependency graph toolbar has a fixed height, so the "Show all" button appearing/disappearing no longer resizes the toolbar and shifts the canvas.
+    - Panel-header action buttons ("Clear", "Show all") now sit flush against the panel's right edge — a `Flexible` title competing with a `Spacer` used to leave a dead gap after the actions at wide layouts.
+    - The Provider Details status row (badge + Invalidate/Refresh) scales down gracefully at narrow panel widths instead of overflowing.
 - **Infrastructure & UX** ([#57](https://github.com/yutsuki3/riverpod_devtools/issues/57)):
     - **MCP port auto-discovery**: the in-app HTTP server now binds the first free port in `8788`–`8797` instead of failing when `8788` is taken, so two debug apps can run at once. The MCP server discovers running apps by probing the range; a new `list_riverpod_apps` tool reports each app's port / provider count / event count, and every tool accepts an optional `port` to target a specific app (auto-selected when only one is running).
 - **Performance diagnostics: update frequency, async load duration, churn** ([#56](https://github.com/yutsuki3/riverpod_devtools/issues/56)):

--- a/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
+++ b/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
@@ -294,6 +294,38 @@ class InspectorNotifier extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Clears the whole selection in one step (one state change, one
+  /// notification) — used by "tap empty area" and the header's Clear
+  /// button. Removing providers one by one would rebuild the UI once per
+  /// selected provider.
+  void clearSelection() {
+    if (_state.selectedProviderNames.isEmpty &&
+        _state.activeTabProviderName == null) {
+      return;
+    }
+    _setState(_state.copyWith(
+      selectedProviderNames: const {},
+      activeTabProviderName: null,
+    ));
+    notifyListeners();
+  }
+
+  /// Replaces the selection with just [providerName] in one step, or clears
+  /// it when the provider was already the only selection (plain-click
+  /// toggle semantics).
+  void selectOnly(String providerName) {
+    final current = _state.selectedProviderNames;
+    if (current.length == 1 && current.contains(providerName)) {
+      clearSelection();
+      return;
+    }
+    _setState(_state.copyWith(
+      selectedProviderNames: {providerName},
+      activeTabProviderName: providerName,
+    ));
+    notifyListeners();
+  }
+
   void setActiveTab(String providerName) {
     _setState(_state.copyWith(activeTabProviderName: providerName));
     notifyListeners();

--- a/packages/riverpod_devtools_extension/lib/src/widgets/common/panel_ui.dart
+++ b/packages/riverpod_devtools_extension/lib/src/widgets/common/panel_ui.dart
@@ -69,24 +69,33 @@ class PanelHeader extends StatelessWidget {
             color: theme.colorScheme.primary,
           ),
           const SizedBox(width: 6),
-          Flexible(
-            child: Text(
-              title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                fontWeight: FontWeight.w600,
-                fontSize: 12,
-                letterSpacing: 0.2,
-                color: theme.colorScheme.onSurface,
-              ),
+          // The title group owns exactly the space the actions don't use, so
+          // the actions sit flush right. (A Flexible title next to a Spacer
+          // would split the free space with it and leave a dead gap after
+          // the actions.)
+          Expanded(
+            child: Row(
+              children: [
+                Flexible(
+                  child: Text(
+                    title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontWeight: FontWeight.w600,
+                      fontSize: 12,
+                      letterSpacing: 0.2,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                  ),
+                ),
+                if (count != null) ...[
+                  const SizedBox(width: 6),
+                  CountBadge(count: count!),
+                ],
+              ],
             ),
           ),
-          if (count != null) ...[
-            const SizedBox(width: 6),
-            CountBadge(count: count!),
-          ],
-          const Spacer(),
           ...actions,
         ],
       ),

--- a/packages/riverpod_devtools_extension/lib/src/widgets/detail_panel/detail_panel.dart
+++ b/packages/riverpod_devtools_extension/lib/src/widgets/detail_panel/detail_panel.dart
@@ -188,10 +188,21 @@ class DetailPanel extends StatelessWidget {
                     StatusBadge(
                       isActive: provider.status == ProviderStatus.active,
                     ),
-                    const Spacer(),
-                    _CommandButtons(
-                      providerName: provider.name,
-                      enabled: provider.status == ProviderStatus.active,
+                    const SizedBox(width: 8),
+                    // The panel is user-resizable: at narrow widths the
+                    // command buttons scale down instead of overflowing.
+                    Expanded(
+                      child: Align(
+                        alignment: Alignment.centerRight,
+                        child: FittedBox(
+                          fit: BoxFit.scaleDown,
+                          child: _CommandButtons(
+                            providerName: provider.name,
+                            enabled:
+                                provider.status == ProviderStatus.active,
+                          ),
+                        ),
+                      ),
                     ),
                   ],
                 ),
@@ -1440,7 +1451,11 @@ class _CommandButtonsState extends State<_CommandButtons> {
       mainAxisSize: MainAxisSize.min,
       children: [
         if (_feedback != null) ...[
-          Flexible(
+          // A fixed cap instead of Flexible: this row now renders inside a
+          // FittedBox, whose unbounded constraints are incompatible with
+          // flex children.
+          ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 140),
             child: Text(
               _feedback!,
               maxLines: 1,

--- a/packages/riverpod_devtools_extension/lib/src/widgets/graph/graph_view.dart
+++ b/packages/riverpod_devtools_extension/lib/src/widgets/graph/graph_view.dart
@@ -133,7 +133,11 @@ class _GraphToolbar extends StatelessWidget {
     final focus = state.graphFocusProvider;
 
     return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      // Fixed height, matching PanelHeader: the "Show all" action (and the
+      // cycle badge) come and go, and without a fixed height their
+      // appearance would resize the toolbar and shift the canvas below.
+      height: 36,
+      padding: const EdgeInsets.symmetric(horizontal: 10),
       decoration: BoxDecoration(
         border: Border(
           bottom: BorderSide(
@@ -146,52 +150,66 @@ class _GraphToolbar extends StatelessWidget {
           Icon(Icons.account_tree_outlined,
               size: 14, color: theme.colorScheme.onSurfaceVariant),
           const SizedBox(width: 6),
-          Text(
-            'Dependency Graph',
-            style: TextStyle(
-              fontSize: 11,
-              fontWeight: FontWeight.w600,
-              color: theme.colorScheme.onSurface,
-            ),
-          ),
-          const SizedBox(width: 8),
-          Text(
-            '${layout.nodes.length} providers',
-            style: TextStyle(
-              fontSize: 9.5,
-              color: theme.colorScheme.onSurfaceVariant.withValues(alpha: 0.7),
-            ),
-          ),
-          if (hasVisibleCycle) ...[
-            const SizedBox(width: 8),
-            Tooltip(
-              message: 'Dependency cycle detected — highlighted in red',
-              child: Container(
-                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                decoration: BoxDecoration(
-                  color: theme.colorScheme.error.withValues(alpha: 0.12),
-                  borderRadius: BorderRadius.circular(999),
+          // The title group owns exactly the space the action doesn't use,
+          // keeping "Show all" flush right (see PanelHeader for the layout
+          // rationale) while the title still ellipsizes when tight.
+          Expanded(
+            child: Row(
+              children: [
+                Flexible(
+                  child: Text(
+                    'Dependency Graph',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: 11,
+                      fontWeight: FontWeight.w600,
+                      color: theme.colorScheme.onSurface,
+                    ),
+                  ),
                 ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Icon(Icons.sync_problem,
-                        size: 11, color: theme.colorScheme.error),
-                    const SizedBox(width: 3),
-                    Text(
-                      'cycle',
-                      style: TextStyle(
-                        fontSize: 9,
-                        fontWeight: FontWeight.w600,
-                        color: theme.colorScheme.error,
+                const SizedBox(width: 8),
+                Text(
+                  '${layout.nodes.length} providers',
+                  style: TextStyle(
+                    fontSize: 9.5,
+                    color: theme.colorScheme.onSurfaceVariant
+                        .withValues(alpha: 0.7),
+                  ),
+                ),
+                if (hasVisibleCycle) ...[
+                  const SizedBox(width: 8),
+                  Tooltip(
+                    message: 'Dependency cycle detected — highlighted in red',
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.error.withValues(alpha: 0.12),
+                        borderRadius: BorderRadius.circular(999),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Icon(Icons.sync_problem,
+                              size: 11, color: theme.colorScheme.error),
+                          const SizedBox(width: 3),
+                          Text(
+                            'cycle',
+                            style: TextStyle(
+                              fontSize: 9,
+                              fontWeight: FontWeight.w600,
+                              color: theme.colorScheme.error,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
-                  ],
-                ),
-              ),
+                  ),
+                ],
+              ],
             ),
-          ],
-          const Spacer(),
+          ),
           if (focus != null)
             HeaderActionButton(
               label: 'Show all',

--- a/packages/riverpod_devtools_extension/lib/src/widgets/provider_list/provider_list_panel.dart
+++ b/packages/riverpod_devtools_extension/lib/src/widgets/provider_list/provider_list_panel.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import '../../models/provider_info.dart';
@@ -43,24 +42,18 @@ class _ProviderListPanelState extends State<ProviderListPanel> {
   /// Applies the click-selection rules used by both standalone tiles and
   /// family-instance tiles (Ctrl/Cmd toggles multi-select; a plain click
   /// selects just this one, or deselects if it was the only selection).
-  void _handleSelect(
-      InspectorState state, String name, bool isSelected, bool isCtrlOrCmd) {
+  /// Reads the notifier's *current* state so the outcome cannot depend on
+  /// how long ago the surrounding widget was built.
+  void _handleSelect(String name, bool isCtrlOrCmd) {
     if (isCtrlOrCmd) {
-      if (isSelected) {
+      if (widget.notifier.state.selectedProviderNames.contains(name)) {
         widget.notifier.removeSelectedProvider(name);
       } else {
         widget.notifier.selectProvider(name);
       }
       return;
     }
-    if (isSelected && state.selectedProviderNames.length == 1) {
-      widget.notifier.removeSelectedProvider(name);
-      return;
-    }
-    for (final selected in state.selectedProviderNames.toList()) {
-      widget.notifier.removeSelectedProvider(selected);
-    }
-    widget.notifier.selectProvider(name);
+    widget.notifier.selectOnly(name);
   }
 
   /// Groups [providers] into display rows: a family with 2+ instances gets
@@ -122,11 +115,7 @@ class _ProviderListPanelState extends State<ProviderListPanel> {
                   HeaderActionButton(
                     label: 'Clear',
                     icon: Icons.close,
-                    onPressed: () {
-                      for (final name in state.selectedProviderNames.toList()) {
-                        widget.notifier.removeSelectedProvider(name);
-                      }
-                    },
+                    onPressed: widget.notifier.clearSelection,
                   ),
               ],
             ),
@@ -221,13 +210,11 @@ class _ProviderListPanelState extends State<ProviderListPanel> {
                         )
                       : GestureDetector(
                           behavior: HitTestBehavior.opaque,
-                          onTap: () {
-                            // Tapping empty area deselects all
-                            for (final name
-                                in state.selectedProviderNames.toList()) {
-                              widget.notifier.removeSelectedProvider(name);
-                            }
-                          },
+                          // Tapping empty area deselects all. Tile taps
+                          // never reach this: each tile has its own tap
+                          // recognizer, which wins the gesture arena as
+                          // the deeper node.
+                          onTap: widget.notifier.clearSelection,
                           child: Builder(
                             builder: (context) {
                               final rows = _buildRows(filteredProviders);
@@ -263,16 +250,8 @@ class _ProviderListPanelState extends State<ProviderListPanel> {
                                     isFlashing: state.flashingProviderName ==
                                         provider.name,
                                     isFamilyInstance: row.isFamilyInstance,
-                                    onPointerDown: (event) {
-                                      final isCtrlOrCmd = event.kind ==
-                                              PointerDeviceKind.mouse &&
-                                          (HardwareKeyboard
-                                                  .instance.isMetaPressed ||
-                                              HardwareKeyboard
-                                                  .instance.isControlPressed);
-                                      _handleSelect(state, provider.name,
-                                          isSelected, isCtrlOrCmd);
-                                    },
+                                    onSelect: (isCtrlOrCmd) => _handleSelect(
+                                        provider.name, isCtrlOrCmd),
                                   );
                                 },
                               );
@@ -396,22 +375,39 @@ class _FamilyHeaderTile extends StatelessWidget {
   }
 }
 
-class _ProviderListTile extends StatelessWidget {
+class _ProviderListTile extends StatefulWidget {
   final ProviderInfo provider;
   final ProviderStats? stats;
   final bool isSelected;
   final bool isFlashing;
   final bool isFamilyInstance;
-  final void Function(PointerDownEvent event) onPointerDown;
+
+  /// Called on tap with whether Ctrl/Cmd was held when the press started.
+  final void Function(bool isCtrlOrCmd) onSelect;
 
   const _ProviderListTile({
     required this.provider,
     required this.stats,
     required this.isSelected,
     required this.isFlashing,
-    required this.onPointerDown,
+    required this.onSelect,
     this.isFamilyInstance = false,
   });
+
+  @override
+  State<_ProviderListTile> createState() => _ProviderListTileState();
+}
+
+class _ProviderListTileState extends State<_ProviderListTile> {
+  /// Modifier state captured at pointer-down: by the time onTap fires (on
+  /// pointer-up) the user may already have released Ctrl/Cmd.
+  bool _ctrlOrCmdAtPress = false;
+
+  ProviderInfo get provider => widget.provider;
+  ProviderStats? get stats => widget.stats;
+  bool get isSelected => widget.isSelected;
+  bool get isFlashing => widget.isFlashing;
+  bool get isFamilyInstance => widget.isFamilyInstance;
 
   @override
   Widget build(BuildContext context) {
@@ -423,8 +419,18 @@ class _ProviderListTile extends StatelessWidget {
         ? '(${provider.argument ?? provider.name})'
         : provider.name;
 
-    return Listener(
-      onPointerDown: onPointerDown,
+    // A real tap gesture (not a raw pointer listener): the tile enters the
+    // gesture arena and, as the deeper node, beats the surrounding
+    // "tap empty area to deselect" GestureDetector. With the old
+    // Listener.onPointerDown approach both fired on every click, so
+    // whether a selection survived depended on frame timing.
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTapDown: (_) {
+        _ctrlOrCmdAtPress = HardwareKeyboard.instance.isMetaPressed ||
+            HardwareKeyboard.instance.isControlPressed;
+      },
+      onTap: () => widget.onSelect(_ctrlOrCmdAtPress),
       child: MouseRegion(
         cursor: SystemMouseCursors.click,
         child: AnimatedContainer(

--- a/packages/riverpod_devtools_extension/test/src/widgets/graph_view_test.dart
+++ b/packages/riverpod_devtools_extension/test/src/widgets/graph_view_test.dart
@@ -1,0 +1,106 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_devtools_extension/src/models/provider_info.dart';
+import 'package:riverpod_devtools_extension/src/providers/inspector_notifier.dart';
+import 'package:riverpod_devtools_extension/src/widgets/graph/graph_view.dart';
+
+ProviderInfo _provider(String name, {List<String> dependencies = const []}) =>
+    ProviderInfo(
+      id: name.hashCode.toString(),
+      name: name,
+      value: const {'type': 'int', 'value': 1},
+      status: ProviderStatus.active,
+      dependencies: dependencies,
+      dependenciesSource: DependencySource.static,
+    );
+
+void main() {
+  late InspectorNotifier notifier;
+
+  setUp(() {
+    notifier = InspectorNotifier();
+    notifier.debugSeed(
+      providers: {
+        'aProvider': _provider('aProvider', dependencies: ['bProvider']),
+        'bProvider': _provider('bProvider'),
+      },
+      events: const [],
+    );
+  });
+
+  tearDown(() => notifier.dispose());
+
+  Future<void> pumpGraph(WidgetTester tester) => tester.pumpWidget(
+        MaterialApp(home: Scaffold(body: GraphView(notifier: notifier))),
+      );
+
+  /// The toolbar is the nearest container holding the 'Dependency Graph'
+  /// title (ancestors are reported innermost-first).
+  double toolbarHeight(WidgetTester tester) => tester
+      .getSize(
+        find
+            .ancestor(
+              of: find.text('Dependency Graph'),
+              matching: find.byType(Container),
+            )
+            .first,
+      )
+      .height;
+
+  testWidgets(
+      'toolbar height does not change when the Show all button appears '
+      '(regression: focusing a node used to grow the toolbar and shift '
+      'the canvas)', (tester) async {
+    await pumpGraph(tester);
+
+    expect(find.text('Show all'), findsNothing);
+    final heightWithoutButton = toolbarHeight(tester);
+
+    notifier.selectAndFocusInGraph('aProvider');
+    await tester.pump();
+
+    expect(find.text('Show all'), findsOneWidget);
+    expect(toolbarHeight(tester), heightWithoutButton);
+  });
+
+  testWidgets(
+      'Show all sits flush right in the toolbar at any width '
+      '(regression: a Flexible title next to a Spacer used to leave a '
+      'dead gap after the button)', (tester) async {
+    tester.view.physicalSize = const Size(3000, 1900);
+    tester.view.devicePixelRatio = 2.0;
+    addTearDown(tester.view.reset);
+    await pumpGraph(tester);
+
+    notifier.selectAndFocusInGraph('aProvider');
+    await tester.pump();
+
+    final toolbar = find
+        .ancestor(
+          of: find.text('Dependency Graph'),
+          matching: find.byType(Container),
+        )
+        .first;
+    final gap = tester.getRect(toolbar).right -
+        tester.getRect(find.text('Show all')).right;
+    // Toolbar padding (10) + button inner padding (8) + rounding.
+    expect(gap, lessThan(25),
+        reason: 'Show all must hug the toolbar right edge (gap: $gap)');
+  });
+
+  testWidgets('Show all exits focus and clears the selection',
+      (tester) async {
+    await pumpGraph(tester);
+
+    notifier.selectAndFocusInGraph('aProvider');
+    await tester.pump();
+    expect(notifier.state.graphFocusProvider, 'aProvider');
+
+    await tester.tap(find.text('Show all'));
+    await tester.pump();
+
+    expect(notifier.state.graphFocusProvider, isNull);
+    expect(notifier.state.selectedProviderNames, isEmpty);
+    expect(find.text('Show all'), findsNothing);
+  });
+}

--- a/packages/riverpod_devtools_extension/test/src/widgets/provider_list_panel_test.dart
+++ b/packages/riverpod_devtools_extension/test/src/widgets/provider_list_panel_test.dart
@@ -1,0 +1,192 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_devtools_extension/src/models/provider_info.dart';
+import 'package:riverpod_devtools_extension/src/providers/inspector_notifier.dart';
+import 'package:riverpod_devtools_extension/src/widgets/provider_list/provider_list_panel.dart';
+
+ProviderInfo _provider(String name, {String? family, String? argument}) =>
+    ProviderInfo(
+      id: name.hashCode.toString(),
+      name: name,
+      value: const {'type': 'int', 'value': 1},
+      status: ProviderStatus.active,
+      family: family,
+      argument: argument,
+    );
+
+void main() {
+  late InspectorNotifier notifier;
+  late ScrollController scrollController;
+
+  setUp(() {
+    notifier = InspectorNotifier();
+    scrollController = ScrollController();
+  });
+
+  tearDown(() {
+    notifier.dispose();
+    scrollController.dispose();
+  });
+
+  Future<void> pumpPanel(WidgetTester tester,
+      {List<ProviderInfo>? providers}) async {
+    notifier.debugSeed(
+      providers: {
+        for (final p in providers ??
+            [_provider('counterProvider'), _provider('userProvider')])
+          p.name: p,
+      },
+      events: const [],
+    );
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ProviderListPanel(
+            notifier: notifier,
+            scrollController: scrollController,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('ProviderListPanel selection', () {
+    testWidgets('tapping a tile selects the provider', (tester) async {
+      await pumpPanel(tester);
+
+      await tester.tap(find.text('counterProvider'));
+      await tester.pump();
+
+      expect(notifier.state.selectedProviderNames, {'counterProvider'});
+      expect(notifier.state.activeTabProviderName, 'counterProvider');
+    });
+
+    testWidgets(
+        'selection survives a rebuild between pointer down and up '
+        '(regression: parent deselect-all used to win the gesture arena)',
+        (tester) async {
+      await pumpPanel(tester);
+
+      // Press, let the UI rebuild while the pointer is still down (as
+      // happens with any non-instant click, or when a provider event
+      // triggers a rebuild mid-click), then release.
+      final gesture =
+          await tester.startGesture(tester.getCenter(find.text('counterProvider')));
+      await tester.pump(const Duration(milliseconds: 300));
+      await gesture.up();
+      await tester.pump();
+
+      expect(notifier.state.selectedProviderNames, {'counterProvider'});
+    });
+
+    testWidgets('tapping the selected provider again deselects it',
+        (tester) async {
+      await pumpPanel(tester);
+
+      await tester.tap(find.text('counterProvider'));
+      await tester.pump();
+      await tester.tap(find.text('counterProvider'));
+      await tester.pump();
+
+      expect(notifier.state.selectedProviderNames, isEmpty);
+      expect(notifier.state.activeTabProviderName, isNull);
+    });
+
+    testWidgets('plain click on another provider replaces the selection',
+        (tester) async {
+      await pumpPanel(tester);
+
+      await tester.tap(find.text('counterProvider'));
+      await tester.pump();
+      await tester.tap(find.text('userProvider'));
+      await tester.pump();
+
+      expect(notifier.state.selectedProviderNames, {'userProvider'});
+      expect(notifier.state.activeTabProviderName, 'userProvider');
+    });
+
+    testWidgets('Ctrl+click adds to and removes from the selection',
+        (tester) async {
+      await pumpPanel(tester);
+
+      await tester.tap(find.text('counterProvider'));
+      await tester.pump();
+
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.tap(find.text('userProvider'));
+      await tester.pump();
+      expect(notifier.state.selectedProviderNames,
+          {'counterProvider', 'userProvider'});
+
+      await tester.tap(find.text('userProvider'));
+      await tester.pump();
+      expect(notifier.state.selectedProviderNames, {'counterProvider'});
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+    });
+
+    testWidgets('tapping empty area below the list clears the selection',
+        (tester) async {
+      await pumpPanel(tester);
+
+      await tester.tap(find.text('counterProvider'));
+      await tester.pump();
+      expect(notifier.state.selectedProviderNames, isNotEmpty);
+
+      // The list has two short rows; tap well below them, inside the
+      // opaque deselect area.
+      final listBottomCenter = tester.getBottomLeft(
+            find.byType(ListView),
+          ) +
+          const Offset(100, -20);
+      await tester.tapAt(listBottomCenter);
+      await tester.pump();
+
+      expect(notifier.state.selectedProviderNames, isEmpty);
+    });
+
+    testWidgets('Clear header button clears a multi-selection in one step',
+        (tester) async {
+      await pumpPanel(tester);
+
+      await tester.tap(find.text('counterProvider'));
+      await tester.pump();
+      await tester.sendKeyDownEvent(LogicalKeyboardKey.controlLeft);
+      await tester.tap(find.text('userProvider'));
+      await tester.pump();
+      await tester.sendKeyUpEvent(LogicalKeyboardKey.controlLeft);
+
+      var notifications = 0;
+      notifier.addListener(() => notifications++);
+      await tester.tap(find.text('Clear'));
+      await tester.pump();
+
+      expect(notifier.state.selectedProviderNames, isEmpty);
+      expect(notifications, 1,
+          reason: 'clearing must be one atomic state change');
+    });
+
+    testWidgets('family header toggle collapses instances without '
+        'changing the selection', (tester) async {
+      await pumpPanel(tester, providers: [
+        _provider('plainProvider'),
+        _provider('userProvider(1)', family: 'userProvider', argument: '1'),
+        _provider('userProvider(2)', family: 'userProvider', argument: '2'),
+      ]);
+
+      await tester.tap(find.text('plainProvider'));
+      await tester.pump();
+
+      // Instances are visible under the header, labeled by argument.
+      expect(find.text('(1)'), findsOneWidget);
+
+      await tester.tap(find.text('userProvider'));
+      await tester.pump();
+
+      expect(find.text('(1)'), findsNothing,
+          reason: 'header tap collapses the family');
+      expect(notifier.state.selectedProviderNames, {'plainProvider'},
+          reason: 'header tap must not touch the selection');
+    });
+  });
+}


### PR DESCRIPTION
Provider list (packages/riverpod_devtools_extension):
- Tiles used a raw Listener.onPointerDown while the surrounding
  "tap empty area to deselect" GestureDetector owned the tap gesture, so
  BOTH fired on every tile click: the tile selected on pointer-down and
  the parent deselected on pointer-up. Whether the selection survived
  depended on whether a rebuild landed between down and up — quick
  clicks worked, slow clicks were silently undone. Tiles now use a real
  tap recognizer, which wins the gesture arena as the deeper node, and
  select on tap-up like every other control. Ctrl/Cmd is captured at
  press time so releasing the modifier mid-click still multi-selects.
- New InspectorNotifier.clearSelection()/selectOnly(): clearing or
  replacing the selection is one atomic state change + one notification
  instead of a rebuild per selected provider.

Panel headers:
- The graph toolbar gets a fixed 36px height (same as PanelHeader), so
  the "Show all" button appearing no longer resizes the toolbar and
  shifts the canvas below.
- PanelHeader and the graph toolbar placed a Flexible title next to a
  Spacer; both are flex children, so the title's unused allocation was
  left as a dead gap AFTER the trailing actions — "Clear" / "Show all"
  floated ~250px left of the panel edge at wide layouts. The title
  group is now wrapped in an Expanded, keeping actions flush right
  while the title still ellipsizes when space is tight.
- The Provider Details status row (StatusBadge + Invalidate/Refresh)
  overflowed at narrow panel widths (the panels are user-resizable);
  it now scales down via FittedBox instead of striping.

Tests: new widget tests for the provider list (tap selects, selection
survives a mid-click rebuild — fails against the old code —, toggle,
plain-click replace, Ctrl+click multi-select, empty-area deselect,
atomic Clear, family collapse) and the graph view (stable toolbar
height, flush-right Show all at 1500px, Show all resets focus).

Verified end-to-end on a release web build of the mock harness with
scripted browser clicks: slow click (400ms hold) selects, empty-area
click deselects, node click focuses the graph, Show all appears without
layout shift; screenshots inspected.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y3pHsEyNNohpVFvVq7277f