### PR TITLE
Add Riverpod compatibility testing across 2.x and 3.x versions

### DIFF
--- a/.github/workflows/riverpod-compat.yml
+++ b/.github/workflows/riverpod-compat.yml
@@ -1,0 +1,38 @@
+name: Riverpod compatibility
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      # Keep running the other version even if one fails, so we see both results.
+      fail-fast: false
+      matrix:
+        riverpod:
+          - "^2.6.0"   # 2.x line
+          - "^3.0.0"   # 3.x line
+    defaults:
+      run:
+        working-directory: packages/riverpod_devtools
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Pin flutter_riverpod to ${{ matrix.riverpod }}
+        run: dart run tool/set_riverpod_version.dart "${{ matrix.riverpod }}"
+
+      - name: Resolve dependencies
+        run: flutter pub get
+
+      - name: Print resolved version (for the logs)
+        run: flutter pub deps --no-dev | grep -i riverpod || true
+
+      - name: Run tests
+        run: flutter test

--- a/packages/riverpod_devtools/tool/set_riverpod_version.dart
+++ b/packages/riverpod_devtools/tool/set_riverpod_version.dart
@@ -1,0 +1,32 @@
+// Rewrites the flutter_riverpod (and riverpod, if present) version constraint
+// in pubspec.yaml to the value given as the first CLI argument. Used only by
+// CI (see .github/workflows/riverpod-compat.yml) to test both the 2.x and 3.x
+// lines. Not used at runtime.
+import 'dart:io';
+
+void main(List<String> args) {
+  if (args.isEmpty) {
+    stderr.writeln('Usage: dart run tool/set_riverpod_version.dart <constraint>');
+    exit(64);
+  }
+  final constraint = args.first;
+  final file = File('pubspec.yaml');
+  final lines = file.readAsLinesSync();
+
+  // Match lines like:  "  flutter_riverpod: ^2.6.0"  (any leading indent).
+  final pattern = RegExp(r'^(\s+)(flutter_riverpod|riverpod):\s*.*$');
+  var changed = 0;
+  for (var i = 0; i < lines.length; i++) {
+    final m = pattern.firstMatch(lines[i]);
+    if (m != null) {
+      lines[i] = '${m.group(1)}${m.group(2)}: "$constraint"';
+      changed++;
+    }
+  }
+  if (changed == 0) {
+    stderr.writeln('No riverpod dependency line found in pubspec.yaml.');
+    exit(1);
+  }
+  file.writeAsStringSync('${lines.join('\n')}\n');
+  stdout.writeln('Pinned $changed dependency line(s) to "$constraint".');
+}


### PR DESCRIPTION
## Summary
This PR adds a GitHub Actions workflow to test the riverpod_devtools package against multiple versions of the Riverpod dependency (2.x and 3.x lines), ensuring compatibility across major versions.

## Key Changes
- **New CI workflow** (`.github/workflows/riverpod-compat.yml`): Automated testing matrix that runs tests against both `riverpod ^2.6.0` and `^3.0.0` to catch version-specific issues early
- **Version pinning utility** (`packages/riverpod_devtools/tool/set_riverpod_version.dart`): Helper script that dynamically rewrites pubspec.yaml constraints to test different Riverpod versions, used exclusively by the CI workflow

## Implementation Details
- The workflow uses a matrix strategy with `fail-fast: false` to ensure both version tests complete even if one fails
- The version pinning script uses regex pattern matching to safely update `flutter_riverpod` and `riverpod` dependency constraints in pubspec.yaml
- Tests run on Ubuntu with stable Flutter channel after resolving dependencies for each version
- Dependency resolution is logged for debugging purposes

https://claude.ai/code/session_01F8qhJGv9XQaHvkFLGf3u1B