### PR TITLE
Mark lossy/approximate serialized values with lossy flag

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- **MCP: flag lossy/approximate serialized values**: cyclic references and values truncated by the depth limit now carry `lossy: true` in both the raw and compact serialized forms, so an AI reading the value can tell it's a placeholder rather than an accurate reading.
+
 - **MCP: token-efficient responses**:
     - `get_riverpod_logs` and `get_provider_state` now return a **compact** representation by default — slim events/entries with summarized values, dropping the repeated static-dependency metadata, `providerId`, and the verbose nested `{type, string, items/entries}` value trees that the GUI needs but an AI does not. In a realistic case the compact log payload is about a quarter the size of the raw one, so far more history fits in an AI's context per call.
     - New `view` parameter: `get_riverpod_logs` accepts `compact` (default), `summary` (per-provider counts by kind plus each provider's latest value — "what happened" without the full stream), and `full` (the complete raw events, for when you need a value the compact form summarized). `get_provider_state` accepts `compact` (default) and `full`.

--- a/packages/riverpod_devtools/lib/src/mcp/compact.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/compact.dart
@@ -24,9 +24,14 @@ Object? compactValue(Object? value) {
   if (value is! Map) return value;
 
   final asyncState = value['asyncState'];
+  final lossy = value['lossy'] == true;
   final core = _compactCore(value);
-  if (asyncState is String) {
-    return {'asyncState': asyncState, 'value': core};
+  if (asyncState is String || lossy) {
+    return {
+      if (asyncState is String) 'asyncState': asyncState,
+      if (lossy) 'lossy': true,
+      'value': core,
+    };
   }
   return core;
 }

--- a/packages/riverpod_devtools/lib/src/utils/serialization.dart
+++ b/packages/riverpod_devtools/lib/src/utils/serialization.dart
@@ -21,6 +21,7 @@ Map<String, Object?> serializeValue(
     return {
       'type': value.runtimeType.toString(),
       'value': '<Max Depth Exceeded>',
+      'lossy': true,
     };
   }
 
@@ -34,6 +35,7 @@ Map<String, Object?> serializeValue(
       return {
         'type': value.runtimeType.toString(),
         'value': '<Cyclic Reference>',
+        'lossy': true,
       };
     }
     visited.add(value);

--- a/packages/riverpod_devtools/test/mcp_compact_test.dart
+++ b/packages/riverpod_devtools/test/mcp_compact_test.dart
@@ -50,6 +50,16 @@ void main() {
       expect(compactValue(42), 42);
       expect(compactValue('raw'), 'raw');
     });
+
+    test('preserves the lossy flag as a wrapper', () {
+      final compact = compactValue({
+        'type': 'Foo',
+        'value': '<Cyclic Reference>',
+        'lossy': true,
+      }) as Map;
+      expect(compact['lossy'], true);
+      expect(compact['value'], '<Cyclic Reference>');
+    });
   });
 
   group('compactEvent', () {

--- a/packages/riverpod_devtools/test/serialization_test.dart
+++ b/packages/riverpod_devtools/test/serialization_test.dart
@@ -146,6 +146,36 @@ void main() {
           nextEntries.firstWhere((e) => e['key'] == 'prev')['value'];
 
       expect(prevEntry['value'], '<Cyclic Reference>');
+      expect(prevEntry['lossy'], true);
+    });
+
+    test('marks a max-depth-exceeded value as lossy', () {
+      dynamic deepList = [];
+      for (var i = 0; i < 15; i++) {
+        deepList = [deepList];
+      }
+
+      final result = serializeValue(deepList);
+
+      dynamic current = result;
+      var foundLossy = false;
+      while (current is Map) {
+        if (current['value'] == '<Max Depth Exceeded>') {
+          foundLossy = current['lossy'] == true;
+          break;
+        }
+        if (current['items'] != null && (current['items'] as List).isNotEmpty) {
+          current = (current['items'] as List)[0];
+        } else {
+          break;
+        }
+      }
+      expect(foundLossy, isTrue);
+    });
+
+    test('a normal value is not marked lossy', () {
+      expect(serializeValue(5).containsKey('lossy'), isFalse);
+      expect(serializeValue('hi').containsKey('lossy'), isFalse);
     });
 
     test('a shared object beyond the depth limit is not later mislabeled '


### PR DESCRIPTION
## Summary
This PR adds a `lossy: true` flag to serialized values that are placeholders or approximations rather than accurate representations. This allows AI tools and other consumers of the serialization format to distinguish between actual values and truncated/cyclic references.

## Key Changes
- **Serialization**: Added `lossy: true` flag to values that hit the max depth limit or contain cyclic references in `serializeValue()`
- **Compact format**: Updated `compactValue()` to preserve the `lossy` flag alongside `asyncState` when present, ensuring the flag survives the compaction process
- **Tests**: Added comprehensive test coverage for:
  - Cyclic references being marked as lossy
  - Max-depth-exceeded values being marked as lossy
  - Normal values not having the lossy flag
  - The lossy flag being preserved through the compact transformation

## Implementation Details
- The `lossy` flag is only included in the serialized output when `true`, keeping the JSON minimal for normal values
- In the compact format, `lossy` is treated similarly to `asyncState` — it wraps the core value when present
- Both raw and compact serialization formats now consistently indicate lossy values, enabling downstream consumers (particularly AI models) to understand when a value is a placeholder

https://claude.ai/code/session_017h58Z8ULoevqPXn72tVxPW