### PR TITLE
MCP UX fixes: graph setup-hint, real server version, first-run docs (#81, #82, #83)

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- **MCP: `get_dependency_graph` now explains an empty `edges`** — when no static dependency data is loaded (or none of the running providers match it by name), the response carries an `edgesNote` describing why `edges` is empty and how to fix it, instead of being indistinguishable from "no dependencies". The note survives the compact view.
+- **MCP: the server reports its real version** in the initialize handshake (was hardcoded to `0.1.0`); `tool/release.sh` keeps it in sync.
+- **Docs**: MCP.md now notes the one-time ~10–20s first-launch compile of the MCP server so a client startup timeout on first use isn't mistaken for a failure.
+
 ## 1.0.0
 
 First stable release. This milestone makes the bundled MCP server a first-class, token-efficient interface for AI coding tools — reading live provider state and driving it — and rounds out the DevTools extension with an interactive dependency graph and a per-provider performance/health dashboard. The public API (`RiverpodDevToolsObserver`, the analyzer CLI, the MCP server) is now considered stable and follows semantic versioning.

--- a/packages/riverpod_devtools/MCP.md
+++ b/packages/riverpod_devtools/MCP.md
@@ -40,6 +40,8 @@ claude mcp add --scope project riverpod_devtools_mcp -- dart run riverpod_devtoo
 
 This works the same way as `dart run riverpod_devtools:analyze` — no path needed, since `riverpod_devtools` is already a dependency of your Flutter app.
 
+> **First launch is slow (one-time):** `dart run` compiles the MCP server the first time it starts, which can take ~10–20 seconds before the server responds — some MCP clients may report a startup timeout on that very first attempt. Just retry (or restart your AI tool): subsequent launches reuse the compiled snapshot and start in well under a second. The compile messages go to stderr, so they never interfere with the MCP protocol on stdout. The snapshot is rebuilt after `flutter pub get` / dependency changes.
+
 **2. Run your Flutter app in debug mode**
 
 ```bash
@@ -75,3 +77,4 @@ Every tool below (except `list_riverpod_apps`) accepts an optional `port` parame
 - It does **not** work out of the box for:
   - Real devices (iOS/Android) — the device has its own network namespace; you'd need manual port forwarding (e.g. `iproxy` for iOS, `adb forward tcp:8788 tcp:8788` for Android)
   - Android Emulator — same reason, needs `adb forward tcp:8788 tcp:8788`
+- The first `dart run riverpod_devtools:riverpod_devtools_mcp` launch compiles the server (~10–20s); later launches are fast. If your AI tool times out once right after setup, retry.

--- a/packages/riverpod_devtools/lib/src/graph_builder.dart
+++ b/packages/riverpod_devtools/lib/src/graph_builder.dart
@@ -64,10 +64,31 @@ Map<String, Object?> buildDependencyGraph({
               edge,
         ];
 
+  // In-band setup hint: an empty `edges` is ambiguous — it can mean "no
+  // dependencies" or "static analysis was never loaded". Tell the consumer
+  // (typically an AI) which one it is, and how to fix it.
+  String? edgesNote;
+  if (!registry.hasAnyData) {
+    edgesNote =
+        'No static dependency data is loaded, so "edges" is empty even if '
+        'dependencies exist in the code. In the Flutter app: run '
+        '`dart run riverpod_devtools:analyze`, load '
+        'lib/riverpod_dependencies.json in main() '
+        '(RiverpodDevToolsRegistry.instance.loadFromJson), add it to the '
+        'pubspec assets, then hot-restart.';
+  } else if (runtimeStatus.isNotEmpty &&
+      runtimeStatus.keys.every((name) => !registry!.hasMetadata(name))) {
+    edgesNote =
+        'Static dependency data is loaded, but none of the running providers '
+        'match it by name — edges may be missing or stale. Re-run '
+        '`dart run riverpod_devtools:analyze` and hot-restart.';
+  }
+
   final generatedAt = registry.jsonGeneratedTimestamp;
   return {
     'nodes': nodes,
     'edges': filteredEdges,
+    if (edgesNote != null) 'edgesNote': edgesNote,
     if (generatedAt != null) 'generatedAt': generatedAt.toIso8601String(),
   };
 }

--- a/packages/riverpod_devtools/lib/src/mcp/compact.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/compact.dart
@@ -304,6 +304,9 @@ Map<String, Object?> compactGraph(Map<Object?, Object?> graph) {
               if (e['type'] != null) 'type': e['type'],
             },
     ],
+    // Keep the setup hint (why `edges` is empty) — it's the whole point of
+    // surfacing it, and it must survive the compact view.
+    if (graph['edgesNote'] != null) 'edgesNote': graph['edgesNote'],
   };
 }
 

--- a/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
@@ -12,7 +12,7 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
     : super.fromStreamChannel(
         implementation: Implementation(
           name: 'riverpod-devtools-mcp',
-          version: '0.1.0',
+          version: riverpodDevToolsVersion,
         ),
         instructions:
             'Inspect Riverpod state in a running Flutter app (debug mode, '

--- a/packages/riverpod_devtools/lib/src/mcp_constants.dart
+++ b/packages/riverpod_devtools/lib/src/mcp_constants.dart
@@ -17,3 +17,7 @@ Iterable<int> get riverpodDevToolsMcpPorts => Iterable.generate(
   riverpodDevToolsMcpPortCount,
   (i) => riverpodDevToolsMcpPort + i,
 );
+
+/// The published package version, reported in the MCP initialize handshake.
+/// Kept in sync by tool/release.sh — do not edit by hand during a release.
+const String riverpodDevToolsVersion = '1.0.0';

--- a/packages/riverpod_devtools/test/graph_builder_test.dart
+++ b/packages/riverpod_devtools/test/graph_builder_test.dart
@@ -125,5 +125,26 @@ void main() {
           (graph['nodes'] as List).map((n) => (n as Map)['name']).toList();
       expect(names, ['a', 'b']);
     });
+
+    test('adds an edgesNote when no static data is loaded', () {
+      final graph = buildDependencyGraph(runtimeStatus: {'a': 'active'});
+      expect(graph['edges'], isEmpty);
+      expect(graph['edgesNote'], contains('riverpod_devtools:analyze'));
+    });
+
+    test('adds a name-mismatch edgesNote when data matches no live provider',
+        () {
+      registry.register(
+          const StaticProviderMetadata(name: 'other', dependencies: []));
+      final graph = buildDependencyGraph(runtimeStatus: {'a': 'active'});
+      expect(graph['edgesNote'], contains('match'));
+    });
+
+    test('no edgesNote when a running provider has static metadata', () {
+      registry.register(
+          const StaticProviderMetadata(name: 'a', dependencies: []));
+      final graph = buildDependencyGraph(runtimeStatus: {'a': 'active'});
+      expect(graph.containsKey('edgesNote'), isFalse);
+    });
   });
 }

--- a/packages/riverpod_devtools/test/mcp_compact_test.dart
+++ b/packages/riverpod_devtools/test/mcp_compact_test.dart
@@ -260,6 +260,15 @@ void main() {
   });
 
   group('compactGraph', () {
+    test('preserves the edgesNote setup hint', () {
+      final compact = compactGraph({
+        'nodes': [],
+        'edges': [],
+        'edgesNote': 'run analyze',
+      });
+      expect(compact['edgesNote'], 'run analyze');
+    });
+
     test('keeps topology, drops source locations and bookkeeping', () {
       final raw = {
         'nodes': [

--- a/tool/release.sh
+++ b/tool/release.sh
@@ -38,10 +38,13 @@ sed_inplace() {
   fi
 }
 
-echo "==> Syncing version to $new_version in 3 files"
+echo "==> Syncing version to $new_version in 4 files"
 sed_inplace "s/^version: .*/version: $new_version/" "$pkg_dir/pubspec.yaml"
 sed_inplace "s/^version: .*/version: $new_version/" "$config_file"
 sed_inplace "s/^version: .*/version: $new_version/" "$ext_dir/pubspec.yaml"
+# The MCP server reports this constant in its initialize handshake.
+sed_inplace "s/^const String riverpodDevToolsVersion = .*/const String riverpodDevToolsVersion = '$new_version';/" \
+  "$pkg_dir/lib/src/mcp_constants.dart"
 
 echo "==> Building riverpod_devtools_extension (Flutter web, release mode)"
 (cd "$ext_dir" && flutter build web --release)


### PR DESCRIPTION
Fixes three usability gaps found during an end-to-end run of the MCP setup. Bundled into one PR since each change is small.

## Changes

### #81 — `get_dependency_graph` explains an empty `edges`
Previously, in the most common early state (observer added but `dart run riverpod_devtools:analyze` not yet run), the graph returned `"edges": []` — indistinguishable from "these providers genuinely have no dependencies". The only signal (`hasStaticMetadata: false`) was dropped by the default compact view, so an AI could wrongly conclude the providers are independent.

Now the response carries an `edgesNote` (top-level) when static data is missing, or when it's loaded but matches none of the running providers by name — with the exact fix (`dart run riverpod_devtools:analyze` + load the JSON + hot-restart). `compactGraph` preserves it. Same "surface uncertainty in-band" idea as the `lossy` flag from #70.

### #82 — server reports its real version
The MCP `initialize` handshake advertised a hardcoded `serverInfo.version: "0.1.0"` while the package is `1.0.0`. Added a `riverpodDevToolsVersion` constant (in `mcp_constants.dart`), used it in the server, and taught `tool/release.sh` to keep it in sync (now "4 files").

### #83 — document the first-run compile delay
`dart run riverpod_devtools:riverpod_devtools_mcp` compiles on first launch (~10–20s measured), which can trip an MCP client's startup timeout on first use. Added a note to MCP.md's setup section and the requirements list. Docs only. (Verified separately that the server's stdout is pure JSON-RPC — build messages go to stderr — so the protocol isn't affected.)

## Tests

- New `graph_builder_test.dart` cases: `edgesNote` when no data / name-mismatch, and no note when a running provider has metadata.
- New `mcp_compact_test.dart` case: `compactGraph` preserves `edgesNote`.
- Full suite: **152 tests pass**; `flutter analyze` clean (only the pre-existing generated-asset warning in the example).

Closes #81
Closes #82
Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3pHsEyNNohpVFvVq7277f)_