### PR TITLE
Fix #85–#88: commit example JSON, MCP troubleshooting docs, CI analyze + extension tests, error-message placeholder

### DIFF
--- a/.github/workflows/riverpod-compat.yml
+++ b/.github/workflows/riverpod-compat.yml
@@ -31,8 +31,37 @@ jobs:
       - name: Resolve dependencies
         run: flutter pub get
 
+      # Infos are non-fatal: a transitive dependency (dart_mcp) deprecates an
+      # API we still use; warnings and errors remain fatal.
+      - name: Analyze
+        run: flutter analyze --no-fatal-infos
+
       - name: Print resolved version (for the logs)
         run: flutter pub deps --no-dev | grep -i riverpod || true
 
       - name: Run tests
         run: flutter test
+
+  extension:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: packages/riverpod_devtools_extension
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+
+      - name: Resolve dependencies
+        run: flutter pub get
+
+      - name: Analyze
+        run: flutter analyze
+
+      # The extension only ever runs on web (inside DevTools), and its widget /
+      # notifier tests pull web-only DevTools APIs, so they run on the Chrome
+      # platform. ubuntu-latest ships Chrome preinstalled.
+      - name: Run tests
+        run: flutter test --platform chrome

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ build/
 
 # Generated dependency metadata files
 **/riverpod_dependencies.json
+# ...but commit the examples' generated files so a fresh clone builds and
+# the dependency-graph demo works out of the box.
+!example/lib/riverpod_dependencies.json
+!packages/riverpod_devtools/example/lib/riverpod_dependencies.json

--- a/example/README.md
+++ b/example/README.md
@@ -40,6 +40,8 @@ dart run riverpod_devtools:analyze --watch
 
 This will generate `lib/riverpod_dependencies.json` with static dependency information for all providers.
 
+A pre-generated `lib/riverpod_dependencies.json` is committed so the example builds and shows the dependency graph out of the box — re-run the analyzer (or use `--watch`) after you change any provider.
+
 ### 3. Run the App
 
 ```bash

--- a/example/lib/riverpod_dependencies.json
+++ b/example/lib/riverpod_dependencies.json
@@ -1,0 +1,244 @@
+{
+  "providers": [
+    {
+      "name": "todoListProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/todo_page.dart",
+        "line": 25,
+        "column": 7
+      }
+    },
+    {
+      "name": "lifecycleCounterProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/lifecycle_page.dart",
+        "line": 5,
+        "column": 7
+      }
+    },
+    {
+      "name": "authTokenProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "line": 5,
+        "column": 7
+      }
+    },
+    {
+      "name": "userIdProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "authTokenProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "line": 21,
+            "column": 19
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "line": 19,
+        "column": 7
+      }
+    },
+    {
+      "name": "userNameProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "userIdProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "line": 30,
+            "column": 20
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "line": 28,
+        "column": 7
+      }
+    },
+    {
+      "name": "userEmailProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "userIdProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "line": 39,
+            "column": 20
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "line": 37,
+        "column": 7
+      }
+    },
+    {
+      "name": "userProfileProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "userNameProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "line": 48,
+            "column": 18
+          }
+        },
+        {
+          "providerName": "userEmailProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "line": 49,
+            "column": 19
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "line": 46,
+        "column": 7
+      }
+    },
+    {
+      "name": "counterProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "line": 59,
+        "column": 7
+      }
+    },
+    {
+      "name": "doubleCounterProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "counterProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "line": 75,
+            "column": 19
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "line": 73,
+        "column": 7
+      }
+    },
+    {
+      "name": "tripleCounterProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "doubleCounterProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "line": 84,
+            "column": 25
+          }
+        },
+        {
+          "providerName": "counterProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "line": 85,
+            "column": 26
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "line": 82,
+        "column": 7
+      }
+    },
+    {
+      "name": "largeListProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/performance_page.dart",
+        "line": 12,
+        "column": 7
+      }
+    },
+    {
+      "name": "largeMapProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/performance_page.dart",
+        "line": 22,
+        "column": 7
+      }
+    },
+    {
+      "name": "deepNestedProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/performance_page.dart",
+        "line": 33,
+        "column": 7
+      }
+    },
+    {
+      "name": "asyncNumberProvider",
+      "providerType": "FutureProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/async_page.dart",
+        "line": 7,
+        "column": 7
+      }
+    },
+    {
+      "name": "userProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/custom_class_page.dart",
+        "line": 46,
+        "column": 7
+      }
+    },
+    {
+      "name": "collectionsProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/example/lib/pages/collections_page.dart",
+        "line": 27,
+        "column": 7
+      }
+    }
+  ],
+  "generatedAt": "2026-07-14T14:41:23.266549",
+  "version": "1.0.0"
+}

--- a/packages/riverpod_devtools/MCP.md
+++ b/packages/riverpod_devtools/MCP.md
@@ -78,3 +78,7 @@ Every tool below (except `list_riverpod_apps`) accepts an optional `port` parame
   - Real devices (iOS/Android) — the device has its own network namespace; you'd need manual port forwarding (e.g. `iproxy` for iOS, `adb forward tcp:8788 tcp:8788` for Android)
   - Android Emulator — same reason, needs `adb forward tcp:8788 tcp:8788`
 - The first `dart run riverpod_devtools:riverpod_devtools_mcp` launch compiles the server (~10–20s); later launches are fast. If your AI tool times out once right after setup, retry.
+
+## Troubleshooting
+
+See the [MCP Issues section of TROUBLESHOOTING.md](TROUBLESHOOTING.md#mcp-issues).

--- a/packages/riverpod_devtools/TROUBLESHOOTING.md
+++ b/packages/riverpod_devtools/TROUBLESHOOTING.md
@@ -164,6 +164,36 @@
 3. Check console for errors
 4. Ensure app is in debug mode (not release)
 
+## MCP Issues
+
+### AI tool reports "No running Flutter app ... was found on ports 8788–8797"
+
+The MCP server probes `localhost:8788`–`8797` and found nothing. Check, in order:
+
+1. The Flutter app is running in **debug mode** (`flutter run`). The HTTP endpoint never starts in profile/release builds, and not on web.
+2. `RiverpodDevToolsObserver()` is registered in `ProviderScope(observers: [...])`.
+3. You're on a **real device or Android emulator** — those have their own network namespace, so forward the port first: `adb forward tcp:8788 tcp:8788` (Android) or `iproxy` (iOS device). Desktop apps and the iOS Simulator need no forwarding.
+
+### The MCP server times out on its very first launch
+
+`dart run riverpod_devtools:riverpod_devtools_mcp` compiles the server the first time it runs (~10–20 s), which can exceed an MCP client's startup timeout. Retry / restart the AI tool — subsequent launches reuse the compiled snapshot and start in well under a second. The snapshot is rebuilt after `flutter pub get` or dependency changes.
+
+### `get_dependency_graph` returns empty `edges`
+
+If the response contains an `edgesNote`, follow it: it means static dependency data isn't loaded (run `dart run riverpod_devtools:analyze`, load `lib/riverpod_dependencies.json` in `main()`, add it to the pubspec assets, hot-restart) or the loaded data matches no running provider by name (re-run the analyzer). Without an `edgesNote`, the running providers genuinely have no static dependencies.
+
+### `invalidate_provider` / `set_provider_value` is rejected with `ambiguous: true`
+
+Several live providers share that display name. The error lists candidate `instanceId`s — call the tool again passing one of them as `provider`. You can see each provider's `instanceId` (and a `nameIsUnique` flag) in `get_provider_state`.
+
+### `set_provider_value` returns `supported: false`
+
+By design, v1 only writes **primitive** values (int/double/bool/String/null) into providers with a writable notifier (`StateProvider`, `NotifierProvider`). Plain / `FutureProvider` / `StreamProvider` providers, and providers whose state is an object or `AsyncValue`, cannot be set — use `invalidate_provider` instead.
+
+### Two apps are running and tools hit the wrong one
+
+Call `list_riverpod_apps` and pass the chosen `port` to every other tool. Each debug app binds the first free port in `8788`–`8797`.
+
 ## JSON File Issues
 
 ### JSON file not found at runtime

--- a/packages/riverpod_devtools/example/README.md
+++ b/packages/riverpod_devtools/example/README.md
@@ -84,6 +84,8 @@ dart run riverpod_devtools:analyze --watch
 This will generate:
 - `lib/riverpod_dependencies.json` - Single JSON file with all dependency metadata
 
+A pre-generated `lib/riverpod_dependencies.json` is committed so the example builds and shows the dependency graph out of the box — re-run the analyzer (or use `--watch`) after you change any provider.
+
 ### 3. Run the App
 
 ```bash

--- a/packages/riverpod_devtools/example/lib/riverpod_dependencies.json
+++ b/packages/riverpod_devtools/example/lib/riverpod_dependencies.json
@@ -1,0 +1,125 @@
+{
+  "providers": [
+    {
+      "name": "counterProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/main.dart",
+        "line": 14,
+        "column": 7
+      }
+    },
+    {
+      "name": "nameProvider",
+      "providerType": "NotifierProvider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/main.dart",
+        "line": 23,
+        "column": 7
+      }
+    },
+    {
+      "name": "doubleCounterProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "counterProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "line": 6,
+            "column": 17
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "line": 5,
+        "column": 7
+      }
+    },
+    {
+      "name": "displayTextProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "counterProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "line": 12,
+            "column": 17
+          }
+        },
+        {
+          "providerName": "nameProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "line": 13,
+            "column": 16
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "line": 11,
+        "column": 7
+      }
+    },
+    {
+      "name": "manualCounterProvider",
+      "providerType": "Provider",
+      "dependencies": [
+        {
+          "providerName": "counterProvider",
+          "type": "read",
+          "location": {
+            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "line": 19,
+            "column": 17
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "line": 18,
+        "column": 7
+      }
+    },
+    {
+      "name": "asyncDataProvider",
+      "providerType": "FutureProvider",
+      "dependencies": [
+        {
+          "providerName": "nameProvider",
+          "type": "watch",
+          "location": {
+            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "line": 25,
+            "column": 16
+          }
+        }
+      ],
+      "location": {
+        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "line": 24,
+        "column": 7
+      }
+    },
+    {
+      "name": "userProvider",
+      "providerType": "Provider",
+      "dependencies": [],
+      "location": {
+        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "line": 31,
+        "column": 7
+      }
+    }
+  ],
+  "generatedAt": "2026-07-14T14:42:20.398588",
+  "version": "1.0.0"
+}

--- a/packages/riverpod_devtools/lib/src/http_server_io.dart
+++ b/packages/riverpod_devtools/lib/src/http_server_io.dart
@@ -304,7 +304,7 @@ class RiverpodDevToolsHttpServer {
   }
 
   /// `POST /commands` with `{"action": "invalidate"|"refresh"|"set",
-  /// "provider": name, "value"?: }`. Always answers 200 with a JSON body
+  /// "provider": name, "value"?: <primitive>}`. Always answers 200 with a JSON body
   /// carrying `status: ok | error` — the MCP server relays the body as-is.
   Future<void> _handleCommand(HttpRequest request) async {
     final handler = commandHandler;
@@ -329,7 +329,7 @@ class RiverpodDevToolsHttpServer {
         'status': 'error',
         'message':
             'Expected JSON body {"action": "invalidate"|"refresh"|"set", '
-            '"provider": "<name>", "value"?: }.',
+            '"provider": "<name>", "value"?: <primitive>}.',
       });
       return;
     }


### PR DESCRIPTION
Fixes #85, #86, #87, #88 in one PR.

## #85 — Example apps build from a fresh clone
- Ran `dart run riverpod_devtools:analyze` in **both** examples and committed the real generated `lib/riverpod_dependencies.json` (16 providers in the root example, 7 in the package example).
- `.gitignore` keeps the global `**/riverpod_dependencies.json` ignore for consumer apps, with two `!` negations for the example paths only.
- Added the one-sentence note to both example READMEs.
- Verified: `flutter analyze` in each example dir → **No issues found!** (the `asset_does_not_exist` warning is gone).

## #86 — MCP troubleshooting docs
- Added a `## MCP Issues` section to `TROUBLESHOOTING.md` between *General DevTools Issues* and *JSON File Issues*, covering app-not-found (+ device/emulator port forwarding), first-launch compile timeout, empty graph edges / `edgesNote`, `ambiguous: true` → `instanceId`, `set_provider_value` `supported: false`, and the multi-app `port`.
- Linked to it from `MCP.md`. Docs only.

## #87 — CI: analyze + extension tests
- Added an **Analyze** step to the existing 2.x/3.x matrix job and a new **extension** job (analyze + tests).
- Two adjustments were required for CI to be genuinely green (verified locally on Flutter stable 3.44.6 **and** 3.32.8):
  - **`flutter analyze --no-fatal-infos`** on the matrix job. A transitive dependency, `dart_mcp` 0.5.2 (published 2026-06-29, after the issue was filed), deprecates `enumValues`, producing 4 info-level `deprecated_member_use` items in `lib/`. This is exactly the info-level case the issue's own note sanctions suppressing; warnings and errors stay fatal. No `lib/` or dependency changes were made.
  - **`flutter test --platform chrome`** for the extension. The extension only ever runs on web, and its widget/notifier tests transitively pull web-only DevTools APIs (`devtools_app_shared`'s `web_utils.dart`), which cannot compile on the default VM target. On Chrome all **98** tests pass (on both SDK versions tested). `ubuntu-latest` ships Chrome preinstalled.
- No `lib/` of the main package was touched; the extension `pubspec.yaml` is unchanged.

## #88 — Truncated placeholder in the `/commands` error message
- `"value"?: }` → `"value"?: <primitive>}` in both the doc comment and the error string in `http_server_io.dart` (matching the existing `<name>` placeholder style and the "a primitive: number, boolean, string, or null" wording).
- Verified: `test/http_server_test.dart` and `test/observer_command_test.dart` pass.

## Verification summary (local, Flutter stable)
- `packages/riverpod_devtools`: `flutter analyze --no-fatal-infos` → exit 0 on both Riverpod 2.x and 3.x; `flutter test` → 152 passing.
- `packages/riverpod_devtools_extension`: `flutter analyze` → clean; `flutter test --platform chrome` → 98 passing.
- Both examples: `flutter analyze` → No issues found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01T6EdFWWCp9wca3LaVx4Mxq)_