### PR TITLE
docs: add CLAUDE.md; test: cover the CLI dependency analyzer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,137 @@
+# CLAUDE.md
+
+Guidance for AI agents (and new contributors) working in this repository.
+Read this before making changes — the architecture has a few non-obvious
+shapes that are easy to get wrong.
+
+## What this project is
+
+A [Flutter DevTools](https://flutter.dev/devtools) extension for
+[Riverpod](https://riverpod.dev): it inspects and monitors providers in
+real time (event log, current values, dependency graph, health stats). It
+also bundles an optional **MCP server** so AI tools can read the same live
+state and drive it (invalidate / refresh / set a provider).
+
+Design values, in priority order: **clear for users, lightweight, stable,
+easy for AI to consume.** New features are *not* a goal — prefer making the
+existing surface clearer, lighter, and more reliable.
+
+## Repository layout
+
+```
+packages/
+  riverpod_devtools/            # Published package (pub.dev)
+    lib/src/observer.dart          # RiverpodDevToolsObserver (in-app entry point)
+    lib/src/http_server_io.dart    # In-app HTTP server (debug only, ports 8788–8797)
+    lib/src/mcp/                    # MCP server + compact.dart (payload reshaping)
+    lib/src/cli/                    # Static dependency analyzer (AST-based)
+    bin/analyze.dart, bin/riverpod_devtools_mcp.dart  # Executables
+    test/                           # Unit tests (strong coverage here)
+  riverpod_devtools_extension/   # DevTools extension UI (Flutter web app)
+    lib/src/providers/inspector_notifier.dart  # Consumes the event stream
+example/                         # Standalone example app
+tool/release.sh                  # Builds the extension web app + copies it into the package
+```
+
+## Data flow — there are TWO parallel paths
+
+The observer is the single source of events. Each Riverpod lifecycle
+callback serializes the value, builds an event map, and fans out to **two
+independent consumers**:
+
+```
+                                   ┌─ developer.postEvent('riverpod:*')  ──▶ DevTools UI
+RiverpodDevToolsObserver ──event──┤    (VM service Extension stream)         (extension package)
+                                   └─ in-app HTTP server (debug only)  ──▶ MCP server ──▶ AI tool
+                                        ports 8788–8797                     (compact.dart reshapes)
+```
+
+- **Path 1 (UI):** `postEvent` → the extension package's `InspectorNotifier`
+  decodes events into typed models and renders them.
+- **Path 2 (MCP):** the observer feeds an in-app HTTP server; the separate
+  `riverpod_devtools_mcp` process discovers it (probes the port range),
+  fetches `/logs` `/providers` `/graph` `/stats`, and reshapes payloads via
+  `lib/src/mcp/compact.dart` before returning them to the AI.
+
+**Naming gotcha:** "MCP server" is overloaded. The in-app **HTTP server**
+(`http_server_io.dart`) is what MCP connects to; the **MCP process**
+(`bin/riverpod_devtools_mcp.dart`) is a separate stdio server. Be explicit
+about which one you mean.
+
+HTTP endpoints: `/ping`, `/logs`, `/providers`, `/graph`, `/stats`,
+`POST /commands`, `DELETE /logs`.
+MCP tools: `list_riverpod_apps`, `get_riverpod_logs`, `get_provider_state`,
+`get_dependency_graph`, `get_provider_stats`, `invalidate_provider`,
+`set_provider_value`, `clear_riverpod_logs`.
+
+## The two packages do NOT share code
+
+This is deliberate (`packages/riverpod_devtools/lib/src/provider_stats.dart`
+documents it) and the single biggest footgun. Logic is **implemented twice**,
+so a rule change must be made in both places or the UI and MCP will disagree:
+
+| Concept        | Package copy                                        | Extension copy                                                    |
+|----------------|-----------------------------------------------------|-------------------------------------------------------------------|
+| Provider stats | `lib/src/provider_stats.dart`                       | `lib/src/utils/provider_stats.dart`                               |
+| Event model    | serialized in `observer.dart` / `utils/serialization.dart` | `lib/src/models/provider_event.dart`, `provider_info.dart` |
+
+When you change stats thresholds or the event shape, **grep both packages.**
+
+## Wire format is an implicit contract across THREE places
+
+The serialized event/value shape is coupled, with no shared schema. If you
+change it, update all three:
+
+1. **Producer** — `lib/src/utils/serialization.dart` + `observer.dart`
+   (`_buildProviderEventData`).
+2. **MCP reshaper** — `lib/src/mcp/compact.dart`.
+3. **UI decoder** — extension `inspector_notifier.dart` (`_normalizeValue`, `_subscribeToEvents`).
+
+## Compact vs full (MCP output contract)
+
+`compact.dart` is the AI-facing reshaping layer and is purely functional /
+heavily unit-tested. Keep it that way.
+
+- Values over `_maxValueChars` (200) collapse to summaries like
+  `Type(n items)` / `{…n keys}`; the `lossy: true` flag is preserved so the
+  AI knows truncation happened.
+- Stats are ordered most-interesting-first.
+- `edgesNote` setup hints are preserved even in compact view.
+- `view: "full"` is the escape hatch that returns the untruncated payload.
+
+The MCP tool descriptions (in `riverpod_devtools_mcp_server.dart`) are
+carefully written — they state mutation effects, auto-port behavior, and
+ambiguity handling. Treat them as part of the product; keep them accurate.
+
+## Commands
+
+```bash
+# Main package (from packages/riverpod_devtools)
+flutter pub get
+flutter analyze
+flutter test
+
+# Extension UI (from packages/riverpod_devtools_extension)
+flutter pub get
+flutter analyze
+flutter test
+
+# Rebuild the extension and copy the web build into the published package
+./tool/release.sh          # builds riverpod_devtools_extension and copies to
+                           # packages/riverpod_devtools/extension/devtools/build
+
+# Regenerate an example's static dependency graph (run from that example dir)
+dart run riverpod_devtools:analyze
+```
+
+The built extension lives in
+`packages/riverpod_devtools/extension/devtools/build/` and ships with the
+package. `analyzer` and `dart_mcp` are runtime dependencies (used by the
+CLI / MCP binaries), which is why the SDK minimums are relatively high.
+
+## Conventions
+
+- The observer's HTTP server and MCP path only run in **debug mode**; they
+  never start in profile/release or on web.
+- Keep changes minimal and behavior-preserving unless the task says
+  otherwise. Prefer adding a regression test over expanding scope.

--- a/packages/riverpod_devtools/test/cli_analyzer_json_test.dart
+++ b/packages/riverpod_devtools/test/cli_analyzer_json_test.dart
@@ -1,0 +1,116 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_devtools/src/builder/provider_metadata.dart';
+import 'package:riverpod_devtools/src/static_dependencies.dart';
+
+/// Builds the JSON envelope that the CLI analyzer writes to
+/// `lib/riverpod_dependencies.json`, so we can assert the contract between
+/// the analyzer's output format and [RiverpodDevToolsRegistry.loadFromJson]
+/// without invoking the analyzer binary (which needs a resolved analysis
+/// context and a Flutter SDK).
+String _analyzerJson(List<ProviderMetadata> providers) {
+  final map = {
+    'providers': providers.map((p) => p.toJson()).toList(),
+    'generatedAt': '2026-07-14T00:00:00.000',
+    'version': '1.0.0',
+  };
+  return const JsonEncoder.withIndent('  ').convert(map);
+}
+
+ProviderMetadata _provider(
+  String name,
+  String type,
+  List<DependencyInfo> dependencies,
+) {
+  return ProviderMetadata(
+    name: name,
+    providerType: type,
+    dependencies: dependencies,
+    location: const SourceLocation(file: 'lib/main.dart', line: 1, column: 1),
+  );
+}
+
+DependencyInfo _dep(String name, DependencyType type) {
+  return DependencyInfo(
+    providerName: name,
+    type: type,
+    location: const SourceLocation(file: 'lib/main.dart', line: 2, column: 3),
+  );
+}
+
+void main() {
+  final registry = RiverpodDevToolsRegistry.instance;
+
+  setUp(registry.clear);
+  tearDown(registry.clear);
+
+  group('analyzer JSON -> registry round-trip', () {
+    test('loads providers and their dependency names', () {
+      final json = _analyzerJson([
+        _provider('b', 'Provider', [_dep('a', DependencyType.watch)]),
+        _provider('a', 'StateProvider', []),
+      ]);
+
+      registry.loadFromJson(json);
+
+      expect(registry.count, 2);
+      expect(registry.allProviderNames, containsAll(['a', 'b']));
+      expect(registry.hasMetadata('b'), isTrue);
+      expect(registry.getDependencyNames('b'), ['a']);
+      expect(registry.getDependencyNames('a'), isEmpty);
+    });
+
+    test('preserves dependency type and source location details', () {
+      final json = _analyzerJson([
+        _provider('consumer', 'Provider', [
+          _dep('watched', DependencyType.watch),
+          _dep('read', DependencyType.read),
+          _dep('listened', DependencyType.listen),
+        ]),
+      ]);
+
+      registry.loadFromJson(json);
+
+      final details = registry.getDependenciesWithDetails('consumer');
+      expect(details, hasLength(3));
+      expect(
+        details.map((d) => '${d['providerName']}:${d['type']}').toList(),
+        ['watched:watch', 'read:read', 'listened:listen'],
+      );
+      expect(details.first['line'], 2);
+      expect(details.first['column'], 3);
+    });
+
+    test('a provider with no dependencies loads cleanly', () {
+      registry.loadFromJson(
+        _analyzerJson([_provider('lonely', 'Provider', [])]),
+      );
+
+      expect(registry.hasMetadata('lonely'), isTrue);
+      expect(registry.getDependencyNames('lonely'), isEmpty);
+    });
+  });
+
+  group('analyzer JSON -> registry resilience', () {
+    test('an empty providers list yields an empty registry', () {
+      registry.loadFromJson(_analyzerJson([]));
+
+      expect(registry.count, 0);
+      expect(registry.hasAnyData, isFalse);
+    });
+
+    test('malformed JSON does not throw and leaves the registry empty', () {
+      expect(() => registry.loadFromJson('{not valid json'), returnsNormally);
+      expect(registry.count, 0);
+    });
+
+    test('JSON missing the providers key does not throw', () {
+      expect(
+        () => registry.loadFromJson('{"generatedAt":"x","version":"1.0.0"}'),
+        returnsNormally,
+      );
+      expect(registry.count, 0);
+    });
+  });
+}

--- a/packages/riverpod_devtools/test/cli_dependency_extractor_test.dart
+++ b/packages/riverpod_devtools/test/cli_dependency_extractor_test.dart
@@ -1,0 +1,166 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/source/line_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_devtools/src/builder/provider_metadata.dart';
+import 'package:riverpod_devtools/src/cli/simple_dependency_extractor.dart';
+import 'package:riverpod_devtools/src/static_dependencies.dart';
+
+/// Parses [source] and returns the initializer expression of the first
+/// top-level variable, plus the unit's [LineInfo]. This mirrors what the
+/// CLI analyzer feeds into [SimpleDependencyExtractor] for each provider.
+({Expression initializer, LineInfo lineInfo}) _firstInitializer(String source) {
+  final parsed = parseString(content: source, throwIfDiagnostics: false);
+  final unit = parsed.unit;
+  for (final declaration in unit.declarations) {
+    if (declaration is TopLevelVariableDeclaration) {
+      final initializer = declaration.variables.variables.first.initializer;
+      if (initializer != null) {
+        return (initializer: initializer, lineInfo: unit.lineInfo);
+      }
+    }
+  }
+  fail('No top-level variable with an initializer found in source');
+}
+
+List<DependencyInfo> _extract(String source) {
+  final parsed = _firstInitializer(source);
+  return SimpleDependencyExtractor.extractDependencies(
+    parsed.initializer,
+    'lib/test.dart',
+    parsed.lineInfo,
+  );
+}
+
+void main() {
+  group('SimpleDependencyExtractor - dependency kinds', () {
+    test('extracts ref.watch as a watch dependency', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  return ref.watch(a);
+});
+''');
+
+      expect(deps, hasLength(1));
+      expect(deps.single.providerName, 'a');
+      expect(deps.single.type, DependencyType.watch);
+    });
+
+    test('extracts ref.read as a read dependency', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  return ref.read(a);
+});
+''');
+
+      expect(deps, hasLength(1));
+      expect(deps.single.providerName, 'a');
+      expect(deps.single.type, DependencyType.read);
+    });
+
+    test('extracts ref.listen as a listen dependency', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  ref.listen(a, (prev, next) {});
+  return 0;
+});
+''');
+
+      expect(deps, hasLength(1));
+      expect(deps.single.providerName, 'a');
+      expect(deps.single.type, DependencyType.listen);
+    });
+
+    test('extracts multiple mixed dependencies in declaration order', () {
+      final deps = _extract('''
+final d = Provider((ref) {
+  final x = ref.watch(a);
+  final y = ref.read(b);
+  ref.listen(c, (prev, next) {});
+  return x + y;
+});
+''');
+
+      expect(
+        deps.map((d) => '${d.providerName}:${d.type.name}').toList(),
+        ['a:watch', 'b:read', 'c:listen'],
+      );
+    });
+  });
+
+  group('SimpleDependencyExtractor - provider name shapes', () {
+    test('resolves .select() to the underlying provider', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  return ref.watch(a.select((v) => v.field));
+});
+''');
+
+      expect(deps.single.providerName, 'a');
+      expect(deps.single.type, DependencyType.watch);
+    });
+
+    test('resolves prefixed/property access to the property name', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  return ref.watch(providers.counterProvider);
+});
+''');
+
+      expect(deps.single.providerName, 'counterProvider');
+    });
+  });
+
+  group('SimpleDependencyExtractor - edge cases', () {
+    test('returns empty for a provider with no ref calls', () {
+      final deps = _extract('final a = Provider((ref) => 0);');
+      expect(deps, isEmpty);
+    });
+
+    test('ignores calls on non-ref targets', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  return other.watch(a);
+});
+''');
+
+      expect(deps, isEmpty);
+    });
+
+    test('ignores ref methods that are not watch/read/listen', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  ref.invalidate(a);
+  ref.refresh(c);
+  return 0;
+});
+''');
+
+      expect(deps, isEmpty);
+    });
+
+    test('ignores ref calls with no arguments', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  ref.watch();
+  return 0;
+});
+''');
+
+      expect(deps, isEmpty);
+    });
+
+    test('records a source location for each dependency', () {
+      final deps = _extract('''
+final b = Provider((ref) {
+  return ref.watch(a);
+});
+''');
+
+      final location = deps.single.location;
+      expect(location.file, 'lib/test.dart');
+      expect(location.line, greaterThan(0));
+      expect(location.column, greaterThan(0));
+    });
+  });
+}


### PR DESCRIPTION
## 概要

改善提案のうち、**既存の挙動を一切変えない追加のみ**の2件をまとめた PR です（リスクゼロ組）。後続の改善作業の土台になります。

- closes #89（CLAUDE.md）
- refs #93（CLI アナライザのテスト）

## 変更内容

### #89 — `CLAUDE.md`（リポジトリルート）

AI エージェント／新規コントリビュータが誤解しやすい構造を簡潔に文書化しました:

- observer →（`postEvent` / in-app HTTP）→（DevTools UI / MCP）の **2経路データフロー**の図
- **2パッケージがコードを共有しない**設計判断と、二重実装されているファイルの対応表（provider_stats、event モデル）
- wire format を変更する際に触る必要のある **3箇所**（producer / `compact.dart` / UI decoder）
- **compact vs full** の MCP 出力契約（`_maxValueChars`、`lossy`、`edgesNote`、`view:"full"`)
- ビルド・テストコマンド（extension の build→copy 手順を含む）

### #93 — CLI アナライザのテスト（2ファイル）

依存グラフ機能の土台でありながらテストが1件も無かった CLI アナライザに、リグレッションガードを追加しました。

- `cli_dependency_extractor_test.dart`: `SimpleDependencyExtractor` を、実際にパースした provider initializer に対して検証。`ref.watch` / `read` / `listen` の種別、`.select` および prefixed/property access の provider 名解決、ソース位置、エッジケース（ref 呼び出しなし・非 ref ターゲット・watch/read/listen 以外のメソッド・引数なし）をカバー。
- `cli_analyzer_json_test.dart`: 解析器が出力する JSON エンベロープが `RiverpodDevToolsRegistry.loadFromJson` を正しく往復すること（provider/依存名、依存の type・location 詳細）と、空・不正入力への耐性を検証。

いずれも `lib/` のコード変更はありません。

## テスト

- **注記:** 作業環境に Dart/Flutter SDK が無く、ローカルでのテスト実行はできていません。本 PR の CI（`flutter analyze` + `flutter test`）が実行検証を行います。
- 実行できない分、本番の解析器が使う**解決済み AST**（`getResolvedUnit`）とテストで使える**未解決 AST**（`parseString`）でノード型が変わりうる family 呼び出し（`fooProvider(id)`）のケースは意図的に除外し、両者で挙動が一致する構文的に確実なケースのみでテストを構成しています。`loadFromJson` / `toJson` の契約も実コードと逐一照合済みです。

## 補足

`#93` を `closes` ではなく `refs` にしているのは、family 呼び出しの解決済み AST 挙動を SDK のある環境で追検証したうえでクローズするのが望ましいためです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdVpiY5yHAWVXYQAdCyLms)_