### PR TITLE
perf: bound serializer breadth/string size; surface dependency-load failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,13 @@ The MCP tool descriptions (in `riverpod_devtools_mcp_server.dart`) are
 carefully written — they state mutation effects, auto-port behavior, and
 ambiguity handling. Treat them as part of the product; keep them accurate.
 
+**Serializer caps (upstream of compact).** `serializeValue`
+(`lib/src/utils/serialization.dart`) bounds work/payload *at the source*, on
+both paths: depth (10), collection breadth (first 100 elements, with
+`truncated`/`totalItems`), and toString() length (4000 chars). Anything
+trimmed is flagged `lossy: true`. `compactValue` prefers `totalItems` when
+summarizing a truncated collection so the reported count is the true size.
+
 ## Commands
 
 ```bash

--- a/packages/riverpod_devtools/README.md
+++ b/packages/riverpod_devtools/README.md
@@ -76,8 +76,11 @@ See [MCP.md](MCP.md) for setup — it takes one `.mcp.json` entry.
           'lib/riverpod_dependencies.json',
         );
         RiverpodDevToolsRegistry.instance.loadFromJson(jsonString);
-      } catch (_) {
-        // DevTools will show setup instructions if JSON is not available
+      } catch (e) {
+        // The asset is missing or unreadable. Log the reason instead of
+        // swallowing it silently — otherwise the dependency graph is just
+        // empty with no hint as to why.
+        debugPrint('riverpod_devtools: could not load dependency data: $e');
       }
 
       runApp(

--- a/packages/riverpod_devtools/lib/src/graph_builder.dart
+++ b/packages/riverpod_devtools/lib/src/graph_builder.dart
@@ -68,7 +68,13 @@ Map<String, Object?> buildDependencyGraph({
   // dependencies" or "static analysis was never loaded". Tell the consumer
   // (typically an AI) which one it is, and how to fix it.
   String? edgesNote;
-  if (!registry.hasAnyData) {
+  if (registry.loadError != null) {
+    edgesNote =
+        'Loading static dependency data FAILED, so "edges" is empty. The JSON '
+        'was found but could not be parsed: ${registry.loadError}. Re-run '
+        '`dart run riverpod_devtools:analyze` to regenerate '
+        'lib/riverpod_dependencies.json, then hot-restart.';
+  } else if (!registry.hasAnyData) {
     edgesNote =
         'No static dependency data is loaded, so "edges" is empty even if '
         'dependencies exist in the code. In the Flutter app: run '

--- a/packages/riverpod_devtools/lib/src/mcp/compact.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/compact.dart
@@ -49,21 +49,30 @@ Object? _compactCore(Map<Object?, Object?> value) {
     if (string.length <= _maxValueChars) return string;
     final type = value['type'];
     if (value['items'] is List) {
-      return '$type(${(value['items'] as List).length} items)';
+      return '$type(${_collectionCount(value, 'items')} items)';
     }
     if (value['entries'] is List) {
-      return '$type(${(value['entries'] as List).length} entries)';
+      return '$type(${_collectionCount(value, 'entries')} entries)';
     }
     return '${string.substring(0, _maxValueChars - 1)}…';
   }
   // No string: summarize whatever structure is present.
   if (value['items'] is List) {
-    return '${value['type']}(${(value['items'] as List).length} items)';
+    return '${value['type']}(${_collectionCount(value, 'items')} items)';
   }
   if (value['entries'] is List) {
-    return '${value['type']}(${(value['entries'] as List).length} entries)';
+    return '${value['type']}(${_collectionCount(value, 'entries')} entries)';
   }
   return value['type'];
+}
+
+/// The count to report for a collection summary. Prefers `totalItems` (the true
+/// size before the serializer capped it), falling back to the serialized
+/// element count when the collection was not truncated.
+int _collectionCount(Map<Object?, Object?> value, String key) {
+  final total = value['totalItems'];
+  if (total is int) return total;
+  return (value[key] as List).length;
 }
 
 /// Inlines a primitive/small structure as-is, or summarizes it when its

--- a/packages/riverpod_devtools/lib/src/observer.dart
+++ b/packages/riverpod_devtools/lib/src/observer.dart
@@ -29,8 +29,11 @@ import 'utils/stack_trace_utils.dart';
 ///   try {
 ///     final jsonString = await rootBundle.loadString('lib/riverpod_dependencies.json');
 ///     RiverpodDevToolsRegistry.instance.loadFromJson(jsonString);
-///   } catch (_) {
-///     // DevTools will show setup instructions if JSON is not available
+///   } catch (e) {
+///     // The asset is missing or unreadable. Log the reason instead of
+///     // swallowing it silently — DevTools/MCP will otherwise just show an
+///     // empty dependency graph with no hint as to why.
+///     debugPrint('riverpod_devtools: could not load dependency data: $e');
 ///   }
 ///
 ///   runApp(
@@ -64,7 +67,6 @@ final class RiverpodDevToolsObserver extends ProviderObserver {
 
   static void _registerCommandExtension() {
     if (_commandExtensionRegistered) return;
-    _commandExtensionRegistered = true;
     try {
       developer.registerExtension(commandExtensionName,
           (method, parameters) async {
@@ -75,6 +77,10 @@ final class RiverpodDevToolsObserver extends ProviderObserver {
             {'status': 'error', 'message': 'No active observer.'};
         return developer.ServiceExtensionResponse.result(jsonEncode(result));
       });
+      // Only mark as registered once registration actually succeeds, so a
+      // failure can be retried by the next observer instead of being latched
+      // off for the rest of the isolate's life.
+      _commandExtensionRegistered = true;
     } catch (error) {
       developer.log(
         'riverpod_devtools: failed to register $commandExtensionName; '

--- a/packages/riverpod_devtools/lib/src/static_dependencies.dart
+++ b/packages/riverpod_devtools/lib/src/static_dependencies.dart
@@ -128,6 +128,12 @@ class RiverpodDevToolsRegistry {
   /// Timestamp when the JSON file was generated (from JSON metadata)
   DateTime? _jsonGeneratedTimestamp;
 
+  /// Reason the most recent [loadFromJson] failed, or null if it succeeded (or
+  /// was never called). Retained — not just printed — so the failure can be
+  /// surfaced in-band (e.g. as a dependency-graph `edgesNote`) instead of
+  /// silently degrading to "no dependencies".
+  String? _lastLoadError;
+
   /// Register metadata for a provider
   ///
   /// This is typically called by generated code, not by user code.
@@ -178,6 +184,7 @@ class RiverpodDevToolsRegistry {
   void clear() {
     _metadata.clear();
     _dependencyNamesCache.clear();
+    _lastLoadError = null;
   }
 
   /// Get the total number of registered providers
@@ -187,6 +194,11 @@ class RiverpodDevToolsRegistry {
   ///
   /// This is useful to distinguish between "no JSON file" vs "JSON exists but provider name mismatch"
   bool get hasAnyData => _metadata.isNotEmpty;
+
+  /// The reason the most recent [loadFromJson] call failed to parse, or null if
+  /// it succeeded or was never called. Use this to tell "the JSON was never
+  /// loaded" apart from "the JSON was loaded but was malformed".
+  String? get loadError => _lastLoadError;
 
   /// Get the timestamp when the JSON was last loaded (app startup time)
   ///
@@ -248,9 +260,12 @@ class RiverpodDevToolsRegistry {
 
       // Record the timestamp when the JSON was successfully loaded
       _lastLoadedTimestamp = DateTime.now();
+      _lastLoadError = null;
     } catch (e) {
-      // Silently fail to not break app startup
-      // In production, users can check the log for issues
+      // Don't rethrow — a bad file must not break app startup. But retain the
+      // reason (in addition to logging it) so DevTools / MCP can surface it,
+      // rather than the failure being invisible.
+      _lastLoadError = e.toString();
       // ignore: avoid_print
       print('Warning: Failed to load riverpod dependencies from JSON: $e');
     }

--- a/packages/riverpod_devtools/lib/src/utils/serialization.dart
+++ b/packages/riverpod_devtools/lib/src/utils/serialization.dart
@@ -5,6 +5,14 @@ Map<String, Object?> serializeValue(
   Set<Object>? visited,
 }) {
   const maxDepth = 10;
+  // Breadth/size caps. Depth alone doesn't bound the work per event: a single
+  // huge List/Map/Set, or an object with a very long toString(), is otherwise
+  // fully serialized on *every* provider add/update (for both previous and new
+  // value). These caps keep per-event cost and payload size bounded; anything
+  // trimmed is flagged with `lossy: true` (plus `totalItems` for collections)
+  // so both the UI and the AI know truncation happened.
+  const maxItems = 100;
+  const maxStringChars = 4000;
 
   if (value == null) {
     return {
@@ -71,28 +79,38 @@ Map<String, Object?> serializeValue(
       // toJson() doesn't exist or failed
     }
 
-    final stringValue = value.toString();
+    final rawString = value.toString();
+    // Cap the stored string form. A long toString() is both a large payload
+    // and (below) expensive to re-parse character-by-character.
+    final stringTooLong = rawString.length > maxStringChars;
+    final stringValue =
+        stringTooLong ? '${rawString.substring(0, maxStringChars)}…' : rawString;
 
     // Try to extract useful information based on type
     final Map<String, Object?> result = {
       'type': value.runtimeType.toString(),
       'string': stringValue,
     };
+    if (stringTooLong) result['lossy'] = true;
 
-    // For collections
+    // For collections. Only the first `maxItems` elements are recursed; the
+    // rest are summarized with `truncated`/`totalItems` so the payload (and the
+    // work to build it) stays bounded regardless of collection size.
     if (value is List) {
-      result['items'] = value.map(recurse).toList();
+      _addItems(result, value, value.length, maxItems, recurse);
       return result;
     } else if (value is Map) {
-      result['entries'] = value.entries.map((entry) {
+      final total = value.length;
+      result['entries'] = value.entries.take(maxItems).map((entry) {
         return {
           'key': entry.key.toString(),
           'value': recurse(entry.value),
         };
       }).toList();
+      _markTruncated(result, total, maxItems);
       return result;
     } else if (value is Set) {
-      result['items'] = value.map(recurse).toList();
+      _addItems(result, value, value.length, maxItems, recurse);
       return result;
     }
 
@@ -100,22 +118,26 @@ Map<String, Object?> serializeValue(
     // below, because e.g. 'AsyncData<int>(value: 5)' also matches the
     // "ClassName(prop: val)" pattern and would return early without it.
     String? asyncState;
-    if (stringValue.startsWith('AsyncData')) {
+    if (rawString.startsWith('AsyncData')) {
       asyncState = 'data';
-    } else if (stringValue.startsWith('AsyncLoading')) {
+    } else if (rawString.startsWith('AsyncLoading')) {
       asyncState = 'loading';
-    } else if (stringValue.startsWith('AsyncError')) {
+    } else if (rawString.startsWith('AsyncError')) {
       asyncState = 'error';
     }
 
-    // Try to parse the toString() representation for custom classes
-    final parsed = _parseToString(stringValue);
-    if (parsed != null) {
-      return {
-        'type': value.runtimeType.toString(),
-        'value': parsed,
-        if (asyncState != null) 'asyncState': asyncState,
-      };
+    // Try to parse the toString() representation for custom classes. Skip the
+    // (character-by-character) parse when the string was truncated: parsing a
+    // cut-off "ClassName(...)" would produce misleading structure.
+    if (!stringTooLong) {
+      final parsed = _parseToString(rawString);
+      if (parsed != null) {
+        return {
+          'type': value.runtimeType.toString(),
+          'value': parsed,
+          if (asyncState != null) 'asyncState': asyncState,
+        };
+      }
     }
 
     if (asyncState != null) {
@@ -127,6 +149,28 @@ Map<String, Object?> serializeValue(
     if (value is! num && value is! bool && value is! String) {
       visited.remove(value);
     }
+  }
+}
+
+/// Serializes the first [maxItems] elements of [iterable] into `result['items']`
+/// and flags truncation when the collection is larger.
+void _addItems(
+  Map<String, Object?> result,
+  Iterable<Object?> iterable,
+  int total,
+  int maxItems,
+  Map<String, Object?> Function(Object?) recurse,
+) {
+  result['items'] = iterable.take(maxItems).map(recurse).toList();
+  _markTruncated(result, total, maxItems);
+}
+
+/// Adds `truncated`/`totalItems`/`lossy` markers when [total] exceeds [maxItems].
+void _markTruncated(Map<String, Object?> result, int total, int maxItems) {
+  if (total > maxItems) {
+    result['truncated'] = true;
+    result['totalItems'] = total;
+    result['lossy'] = true;
   }
 }
 

--- a/packages/riverpod_devtools/test/graph_builder_test.dart
+++ b/packages/riverpod_devtools/test/graph_builder_test.dart
@@ -146,5 +146,17 @@ void main() {
       final graph = buildDependencyGraph(runtimeStatus: {'a': 'active'});
       expect(graph.containsKey('edgesNote'), isFalse);
     });
+
+    test('reports a load failure in the edgesNote, with the reason', () {
+      // A malformed JSON load records an error but does not throw.
+      registry.loadFromJson('{ this is not valid json');
+      expect(registry.loadError, isNotNull);
+
+      final graph = buildDependencyGraph(runtimeStatus: {'a': 'active'});
+      expect(graph['edges'], isEmpty);
+      final note = graph['edgesNote'] as String;
+      expect(note, contains('FAILED'));
+      expect(note, contains('riverpod_devtools:analyze'));
+    });
   });
 }

--- a/packages/riverpod_devtools/test/mcp_compact_test.dart
+++ b/packages/riverpod_devtools/test/mcp_compact_test.dart
@@ -19,11 +19,14 @@ void main() {
     });
 
     test('summarizes a large collection instead of inlining it', () {
+      // A collection past the serializer's element cap comes through as a
+      // lossy wrapper, and the summary reports the true (pre-cap) size.
       final big = List<int>.generate(500, (i) => i);
-      final compact = compactValue(serializeValue(big));
-      expect(compact, isA<String>());
-      expect(compact as String, contains('500 items'));
-      expect(compact.length, lessThan(40));
+      final compact = compactValue(serializeValue(big)) as Map;
+      expect(compact['lossy'], true);
+      final summary = compact['value'] as String;
+      expect(summary, contains('500 items'));
+      expect(summary.length, lessThan(40));
     });
 
     test('keeps a toJson() structure inline when small', () {

--- a/packages/riverpod_devtools/test/serialization_test.dart
+++ b/packages/riverpod_devtools/test/serialization_test.dart
@@ -3,6 +3,13 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:riverpod_devtools/src/utils/serialization.dart';
 
+/// An object whose toString() is a class-like string longer than the
+/// serializer's string cap, used to verify truncated strings are not parsed.
+class _LongToString {
+  @override
+  String toString() => 'Huge(field: ${'y' * 10000})';
+}
+
 class TestObject {
   final String id;
   TestObject? child;
@@ -176,6 +183,64 @@ void main() {
     test('a normal value is not marked lossy', () {
       expect(serializeValue(5).containsKey('lossy'), isFalse);
       expect(serializeValue('hi').containsKey('lossy'), isFalse);
+    });
+
+    group('breadth/size caps', () {
+      test('caps a large List and reports the true size', () {
+        final result = serializeValue(List<int>.generate(5000, (i) => i));
+
+        expect((result['items'] as List).length, 100);
+        expect(result['truncated'], true);
+        expect(result['totalItems'], 5000);
+        expect(result['lossy'], true);
+        // The capped payload is still encodable.
+        expect(() => jsonEncode(result), returnsNormally);
+      });
+
+      test('caps a large Map and reports the true size', () {
+        final big = {for (var i = 0; i < 5000; i++) 'k$i': i};
+        final result = serializeValue(big);
+
+        expect((result['entries'] as List).length, 100);
+        expect(result['truncated'], true);
+        expect(result['totalItems'], 5000);
+        expect(result['lossy'], true);
+      });
+
+      test('caps a large Set and reports the true size', () {
+        final result = serializeValue(List<int>.generate(5000, (i) => i).toSet());
+
+        expect((result['items'] as List).length, 100);
+        expect(result['totalItems'], 5000);
+        expect(result['lossy'], true);
+      });
+
+      test('a collection at the cap is not marked truncated', () {
+        final result = serializeValue(List<int>.generate(100, (i) => i));
+
+        expect((result['items'] as List).length, 100);
+        expect(result.containsKey('truncated'), isFalse);
+        expect(result.containsKey('lossy'), isFalse);
+      });
+
+      test('caps a very long string value and flags it lossy', () {
+        final result = serializeValue('x' * 10000);
+
+        final string = result['string'] as String;
+        expect(string.length, lessThan(10000));
+        expect(string.endsWith('…'), isTrue);
+        expect(result['lossy'], true);
+      });
+
+      test('does not parse a truncated ClassName(...) string into structure', () {
+        // A giant "class-like" string must not be parsed (which would produce
+        // misleading fields from a cut-off representation).
+        final result = serializeValue(_LongToString());
+
+        expect(result.containsKey('value'), isFalse);
+        expect(result['string'], isA<String>());
+        expect(result['lossy'], true);
+      });
     });
 
     test('a shared object beyond the depth limit is not later mislabeled '

--- a/packages/riverpod_devtools/test/static_dependencies_test.dart
+++ b/packages/riverpod_devtools/test/static_dependencies_test.dart
@@ -391,5 +391,40 @@ void main() {
       expect(retrieved, equals(metadata2));
       expect(retrieved?.dependencies.first.providerName, 'dep2');
     });
+
+    test('loadError is null before any load', () {
+      expect(RiverpodDevToolsRegistry.instance.loadError, isNull);
+    });
+
+    test('malformed JSON does not throw but records loadError', () {
+      final registry = RiverpodDevToolsRegistry.instance;
+
+      expect(
+        () => registry.loadFromJson('{ not valid json'),
+        returnsNormally,
+      );
+      expect(registry.loadError, isNotNull);
+      expect(registry.hasAnyData, isFalse);
+    });
+
+    test('a successful load clears a previous loadError', () {
+      final registry = RiverpodDevToolsRegistry.instance;
+
+      registry.loadFromJson('{ not valid json');
+      expect(registry.loadError, isNotNull);
+
+      registry.loadFromJson('{"providers": [], "version": "1.0.0"}');
+      expect(registry.loadError, isNull);
+    });
+
+    test('clear() resets loadError', () {
+      final registry = RiverpodDevToolsRegistry.instance;
+
+      registry.loadFromJson('{ not valid json');
+      expect(registry.loadError, isNotNull);
+
+      registry.clear();
+      expect(registry.loadError, isNull);
+    });
   });
 }


### PR DESCRIPTION
## 概要

改善提案のうち、**挙動が変わる 2 件**をまとめた PR です（`riverpod_devtools` パッケージ + ドキュメントに閉じた変更）。

- Refs #90（シリアライズの要素数・文字列サイズの上限）
- Refs #92（依存読み込み失敗の可視化）

## 変更内容

### #90 — シリアライズの要素数・文字列サイズの上限

`serializeValue`（`lib/src/utils/serialization.dart`）はこれまで**深さ (10) のみ**を制限しており、数千要素の List/Map/Set や非常に長い `toString()` を持つオブジェクトが、provider の add/update のたびに（previous/new 両方について）全量シリアライズ・JSON エンコードされていました。以下の上限を追加します:

- **コレクション幅:** 先頭 **100 要素**のみ再帰。残りは `truncated` / `totalItems` と `lossy: true` で明示。
- **toString 長:** 保持する `string` を **4000 文字**で打ち切り、超過時は文字単位パース（`_parseToString`）をスキップ（切れた `ClassName(...)` を誤って構造化しない）。
- `compactValue`（MCP 出力）は要約時に `totalItems`（切り詰め前の真の件数）を優先し、AI に正しい件数を提示。

小さい値は上限より十分小さいため**挙動は変わりません**。

### #92 — 依存読み込み失敗の可視化

セットアップ失敗が `print` / `catch (_) {}` で無症状に握りつぶされ、ユーザー・AI ともに「グラフのエッジが空」という遠い症状でしか気づけなかった問題に対処します:

- `RiverpodDevToolsRegistry` が最後の `loadFromJson` の parse エラーを `loadError` として**保持**（成功ロード・`clear()` でリセット）。
- `buildDependencyGraph` が**ロード失敗時に理由付きの専用 `edgesNote`** を出力（既存の「未ロード」「名前不一致」と区別）。MCP 経由で AI に届きます。
- Observer: サービス拡張の登録フラグを**登録成功後にのみ**立て、失敗時に次の observer で再試行可能に。
- README・observer の dartdoc: `catch (_) {}` をやめ、`debugPrint` で理由を出す例に更新。

CLAUDE.md にシリアライザの上限（depth / breadth / toString）を1段落追記しています。

## テスト

追加・更新したテスト:
- コレクション（List/Map/Set）と長い文字列の上限、`truncated`/`totalItems`/`lossy` フラグ、切り詰めた文字列を構造化しないこと（`serialization_test.dart`）。
- compact 要約が `totalItems`（真の件数）を優先し、大コレクションが lossy ラッパーとして返ること（`mcp_compact_test.dart`）。
- registry の `loadError` ライフサイクル（初期 null / 不正 JSON で設定 / 成功で解除 / clear で解除）（`static_dependencies_test.dart`）。
- ロード失敗時の graph `edgesNote`（理由を含む）（`graph_builder_test.dart`）。

**注記:** 作業環境に Dart/Flutter SDK が無く、ローカルでのテスト実行はできていません。本 PR の CI（`flutter analyze` + `flutter test`）が実行検証します。既存テストへの波及（大コレクション要約テストが lossy ラッパー形状に変わる点）は追跡して該当テストを更新済みで、100 要素超のコレクションをシリアライズする他テストが無いことも確認済みです。

## スコープ外（意図的な後回し）

DevTools **UI 側**での失敗表示（新しい `DependencySource` 状態）は extension パッケージ（enum / decoder / session_io / detail_panel）への横断変更になるため、UI を触る後続 PR（#94 / #95 群）に回しています。そのため #90 / #92 は `close` ではなく `refs` にしています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdVpiY5yHAWVXYQAdCyLms)_