### PR TITLE
perf(mcp): cache app discovery so tool calls don't re-scan every port

### DIFF
--- a/packages/riverpod_devtools/lib/src/mcp/app_discovery_cache.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/app_discovery_cache.dart
@@ -1,0 +1,64 @@
+import 'dart:async';
+
+/// The list of discovered apps, as returned by the port-range scan. Each entry
+/// is a `/ping` payload (at least `{'port': int, ...}`).
+typedef DiscoveredApps = List<Map<String, Object?>>;
+
+/// Caches the result of MCP app discovery (the 8788–8797 port scan) for a short
+/// window, so a burst of tool calls in one AI session does not re-ping every
+/// port on every call.
+///
+/// - [get] returns the cached scan while it is fresh (younger than [ttl]),
+///   otherwise runs [discover] and caches the result.
+/// - [refresh] always runs [discover] and primes the cache. Use it for the
+///   explicit "what apps are running?" request, which must not return stale
+///   data.
+/// - [invalidate] drops the cached entry so the next [get] re-scans. Call it
+///   when a request to a previously discovered port fails, so an app that was
+///   restarted onto a different port is picked up instead of being retried
+///   against the dead port.
+///
+/// Behavior is unchanged versus scanning every time — the cache only affects
+/// *when* [discover] runs, never *what* a resolved port talks to.
+class AppDiscoveryCache {
+  AppDiscoveryCache({
+    required this.discover,
+    this.ttl = const Duration(seconds: 5),
+    DateTime Function()? now,
+  }) : _now = now ?? DateTime.now;
+
+  /// Runs the actual port-range scan. Injected so it can be faked in tests.
+  final Future<DiscoveredApps> Function() discover;
+
+  /// How long a scan result stays fresh.
+  final Duration ttl;
+
+  final DateTime Function() _now;
+
+  DiscoveredApps? _apps;
+  DateTime? _at;
+
+  /// Returns the cached scan if still fresh, otherwise scans and caches.
+  Future<DiscoveredApps> get() async {
+    final apps = _apps;
+    final at = _at;
+    if (apps != null && at != null && _now().difference(at) < ttl) {
+      return apps;
+    }
+    return refresh();
+  }
+
+  /// Forces a fresh scan and stores it as the current cache entry.
+  Future<DiscoveredApps> refresh() async {
+    final fresh = await discover();
+    _apps = fresh;
+    _at = _now();
+    return fresh;
+  }
+
+  /// Drops the cached entry; the next [get] will re-scan.
+  void invalidate() {
+    _apps = null;
+    _at = null;
+  }
+}

--- a/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
@@ -5,6 +5,7 @@ import 'dart:io' as io;
 import 'package:dart_mcp/server.dart';
 
 import '../mcp_constants.dart';
+import 'app_discovery_cache.dart';
 import 'compact.dart';
 
 base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
@@ -29,6 +30,12 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
     registerTool(_setProviderValueTool, _setProviderValue);
     registerTool(_clearRiverpodLogsTool, _clearRiverpodLogs);
   }
+
+  /// Caches the port-range scan for a short window so a burst of tool calls in
+  /// one session doesn't re-ping every port each time. Invalidated when a
+  /// request to a discovered port fails.
+  late final AppDiscoveryCache _discoveryCache =
+      AppDiscoveryCache(discover: _discoverApps);
 
   /// Shared optional `port` parameter: pins a tool call to one specific app
   /// when several are running (see `list_riverpod_apps`).
@@ -243,7 +250,9 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
   );
 
   FutureOr<CallToolResult> _listRiverpodApps(CallToolRequest request) async {
-    final apps = await _discoverApps();
+    // Explicit "what's running?" request: force a fresh scan (and prime the
+    // cache) rather than possibly returning a stale list.
+    final apps = await _discoveryCache.refresh();
     return CallToolResult(
       content: [
         TextContent(
@@ -443,7 +452,7 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
       return (port.toInt(), null);
     }
 
-    final apps = await _discoverApps();
+    final apps = await _discoveryCache.get();
     if (apps.isEmpty) {
       return (
         null,
@@ -485,15 +494,22 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
   /// Probes every port in the range and returns the `/ping` payloads of the
   /// apps that respond.
   Future<List<Map<String, Object?>>> _discoverApps() async {
-    final found = await Future.wait(riverpodDevToolsMcpPorts.map(_pingPort));
-    return [
-      for (final app in found)
-        if (app != null) app,
-    ];
+    // One client for the whole scan instead of one per port.
+    final client = io.HttpClient();
+    try {
+      final found = await Future.wait(
+        riverpodDevToolsMcpPorts.map((port) => _pingPort(client, port)),
+      );
+      return [
+        for (final app in found)
+          if (app != null) app,
+      ];
+    } finally {
+      client.close();
+    }
   }
 
-  Future<Map<String, Object?>?> _pingPort(int port) async {
-    final client = io.HttpClient();
+  Future<Map<String, Object?>?> _pingPort(io.HttpClient client, int port) async {
     try {
       final req = await client
           .getUrl(
@@ -514,8 +530,6 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
       return null;
     } catch (_) {
       return null;
-    } finally {
-      client.close();
     }
   }
 
@@ -554,6 +568,10 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
         client.close();
       }
     } catch (e) {
+      // The port we resolved is dead (app stopped, or restarted onto another
+      // port). Drop the cached scan so the next call re-discovers instead of
+      // retrying this same dead port.
+      _discoveryCache.invalidate();
       return CallToolResult(
         content: [
           TextContent(

--- a/packages/riverpod_devtools/test/mcp_app_discovery_cache_test.dart
+++ b/packages/riverpod_devtools/test/mcp_app_discovery_cache_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_devtools/src/mcp/app_discovery_cache.dart';
+
+void main() {
+  group('AppDiscoveryCache', () {
+    late int calls;
+    late DiscoveredApps result;
+    late DateTime clock;
+
+    AppDiscoveryCache build({Duration ttl = const Duration(seconds: 5)}) {
+      return AppDiscoveryCache(
+        ttl: ttl,
+        now: () => clock,
+        discover: () async {
+          calls++;
+          return result;
+        },
+      );
+    }
+
+    setUp(() {
+      calls = 0;
+      result = [
+        {'port': 8788},
+      ];
+      clock = DateTime(2026, 1, 1, 12, 0, 0);
+    });
+
+    test('get() scans on the first call', () async {
+      final cache = build();
+
+      expect(await cache.get(), result);
+      expect(calls, 1);
+    });
+
+    test('get() serves a fresh cache without re-scanning', () async {
+      final cache = build();
+
+      await cache.get();
+      clock = clock.add(const Duration(seconds: 4)); // still within the TTL
+      await cache.get();
+
+      expect(calls, 1);
+    });
+
+    test('get() re-scans once the cache has expired', () async {
+      final cache = build();
+
+      await cache.get();
+      clock = clock.add(const Duration(seconds: 6)); // past the TTL
+      await cache.get();
+
+      expect(calls, 2);
+    });
+
+    test('refresh() always re-scans and primes the cache', () async {
+      final cache = build();
+
+      await cache.refresh();
+      await cache.refresh();
+      expect(calls, 2);
+
+      // A get() right after a refresh is served from cache.
+      await cache.get();
+      expect(calls, 2);
+    });
+
+    test('invalidate() forces the next get() to re-scan', () async {
+      final cache = build();
+
+      await cache.get();
+      cache.invalidate();
+      await cache.get();
+
+      expect(calls, 2);
+    });
+
+    test('a re-scan after invalidate reflects a moved port', () async {
+      final cache = build();
+
+      expect((await cache.get()).single['port'], 8788);
+
+      // App restarted onto a different port; the old port is now dead.
+      result = [
+        {'port': 8789},
+      ];
+      cache.invalidate();
+
+      expect((await cache.get()).single['port'], 8789);
+    });
+  });
+}


### PR DESCRIPTION
## 概要

MCP サーバーは `port` 引数を省略した read 系ツール呼び出しのたびに、8788–8797 の **10 ポート全部を HTTP ping**（各1秒タイムアウト）してアプリを発見していました。AI が連続でツールを呼ぶ典型的なセッション（logs → providers → graph → stats …）では、毎回この発見コストを支払っていました。

- Refs #91

## 変更内容

ポート範囲スキャンの結果を**短時間（5秒）キャッシュ**します。キャッシュロジックは channel 非依存の独立クラス `AppDiscoveryCache`（`lib/src/mcp/app_discovery_cache.dart`）として切り出し、単体テスト可能にしました。

- **read 系（`_resolvePort`）**: キャッシュが新鮮なうちはスキャンを再実行しない。
- **`list_riverpod_apps`**: 明示的な「今何が動いているか」の要求なので、常に fresh スキャン（かつキャッシュを更新）。
- **リクエスト失敗時**: 解決したポートへの接続が失敗したらキャッシュを破棄。アプリが停止・別ポートに再起動した場合、死んだポートを再試行せず次回に再発見する（自己回復）。

挙動はスキャン毎回時と同一です — キャッシュは**スキャンが走るタイミング**だけを変え、解決済みポートが通信する相手は変えません。あわせて、スキャン中の `HttpClient` をポートごとの生成から**スキャン1回につき1つ**に変更しました。

## テスト

`AppDiscoveryCache` のライフサイクルを、注入したクロックとフェイクの discovery でカバー（`mcp_app_discovery_cache_test.dart`）:
- 初回スキャン / TTL 内はキャッシュヒット / TTL 経過後は再スキャン / `refresh()` は常に再スキャンしてキャッシュを更新 / `invalidate()` で次回再スキャン / ポート移動後の再スキャン反映。

**注記:** 作業環境に Dart/Flutter SDK が無く、ローカル実行はできていません。本 PR の CI（`flutter analyze` + `flutter test`）が実行検証します。キャッシュ本体を channel/HttpClient 非依存に切り出したことで、実サーバーを起動せずロジックを決定的にテストできる構成になっています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdVpiY5yHAWVXYQAdCyLms)_