### PR TITLE
perf(extension): reduce per-event list copy and throttle stats recompute

### DIFF
--- a/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
+++ b/packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart
@@ -102,6 +102,17 @@ class InspectorNotifier extends ChangeNotifier {
   /// event anywhere triggers a recompute, rather than ticking down live).
   List<ProviderStats>? _providerStatsCache;
 
+  /// When [_providerStatsCache] was last actually invalidated, used to
+  /// throttle recomputation — see the event-burst handling in [_setState].
+  DateTime? _lastStatsInvalidatedAt;
+  Timer? _statsThrottleTimer;
+
+  /// Minimum spacing between [_providerStatsCache] invalidations. Without
+  /// this, a burst of events (a high-frequency provider ticking many times
+  /// a second) recomputes stats — a full scan + per-provider sort of up to
+  /// 1000 events — on every single one of them.
+  static const Duration _statsThrottle = Duration(milliseconds: 250);
+
   void _setState(InspectorState newState) {
     final old = _state;
     _state = newState;
@@ -117,8 +128,33 @@ class InspectorNotifier extends ChangeNotifier {
     }
     if (!identical(old.events, newState.events)) {
       _eventDepthsCache = null;
-      _providerStatsCache = null;
+      _throttleStatsInvalidation();
     }
+  }
+
+  /// Invalidates [_providerStatsCache] immediately if it's been at least
+  /// [_statsThrottle] since the last invalidation; otherwise defers the
+  /// invalidation to a trailing timer so a burst collapses into at most one
+  /// recompute per throttle window, plus one final recompute once the burst
+  /// settles (so the last few events of a burst are never permanently
+  /// stale).
+  void _throttleStatsInvalidation() {
+    final now = DateTime.now();
+    final last = _lastStatsInvalidatedAt;
+    if (last == null || now.difference(last) >= _statsThrottle) {
+      _providerStatsCache = null;
+      _lastStatsInvalidatedAt = now;
+      _statsThrottleTimer?.cancel();
+      _statsThrottleTimer = null;
+      return;
+    }
+    _statsThrottleTimer?.cancel();
+    _statsThrottleTimer = Timer(_statsThrottle - now.difference(last), () {
+      _providerStatsCache = null;
+      _lastStatsInvalidatedAt = DateTime.now();
+      _statsThrottleTimer = null;
+      notifyListeners();
+    });
   }
 
   static const int _maxEventCount = 1000;
@@ -147,6 +183,7 @@ class InspectorNotifier extends ChangeNotifier {
   void dispose() {
     _extensionSubscription?.cancel();
     _flashTimer?.cancel();
+    _statsThrottleTimer?.cancel();
     super.dispose();
   }
 
@@ -736,18 +773,28 @@ class InspectorNotifier extends ChangeNotifier {
       }
 
       if (newEvent != null) {
-        final newEvents = List<ProviderEvent>.from(_state.events)
-          ..insert(0, newEvent);
+        // Single-pass ring buffer: build the new (newest-first) list at its
+        // final size directly instead of copying the old list (List.from)
+        // and then shifting every element again via insert(0, …) — the
+        // previous approach did two O(n) passes per event.
+        final oldEvents = _state.events;
+        final trimming = oldEvents.length >= _maxEventCount;
+        final newLength =
+            trimming ? _maxEventCount : oldEvents.length + 1;
+        final newEvents =
+            List<ProviderEvent>.filled(newLength, newEvent, growable: false);
+        final keepFromOld = newLength - 1;
+        for (var i = 0; i < keepFromOld; i++) {
+          newEvents[i + 1] = oldEvents[i];
+        }
+
         _eventsByProvider.putIfAbsent(newEvent.providerName, () => []);
         _eventsByProvider[newEvent.providerName]!.insert(0, newEvent);
 
-        // Ring buffer: exactly one event was inserted, so at most one needs
-        // evicting. Evict in place on the copy we just made instead of
-        // copying the whole list a second time.
         Set<String>? newExpanded;
         List<String>? newCompared;
-        if (newEvents.length > _maxEventCount) {
-          final removed = newEvents.removeLast();
+        if (trimming && oldEvents.isNotEmpty) {
+          final removed = oldEvents[oldEvents.length - 1];
 
           final providerEvents = _eventsByProvider[removed.providerName];
           if (providerEvents != null) {

--- a/packages/riverpod_devtools_extension/test/src/providers/inspector_notifier_test.dart
+++ b/packages/riverpod_devtools_extension/test/src/providers/inspector_notifier_test.dart
@@ -206,5 +206,26 @@ void main() {
         expect(notifier.eventDepths[events.last.id], 4);
       });
     });
+
+    group('providerStats throttling', () {
+      test('first update after construction recomputes immediately', () {
+        notifier.debugSetEvents([_updateEvent('a', 1)]);
+        expect(notifier.providerStats, hasLength(1));
+        expect(notifier.providerStats.single.totalUpdateCount, 1);
+      });
+
+      test('a rapid follow-up event is folded in once the throttle '
+          'window elapses, not dropped', () async {
+        notifier.debugSetEvents([_updateEvent('a', 1)]);
+        // Read once so a cache exists to (maybe) go stale.
+        expect(notifier.providerStats.single.totalUpdateCount, 1);
+
+        notifier.debugSetEvents([_updateEvent('a', 2), _updateEvent('a', 1)]);
+        // Give the trailing throttle timer (250ms) time to fire.
+        await Future<void>.delayed(const Duration(milliseconds: 300));
+
+        expect(notifier.providerStats.single.totalUpdateCount, 2);
+      });
+    });
   });
 }


### PR DESCRIPTION
## 概要

`InspectorNotifier`（`packages/riverpod_devtools_extension/lib/src/providers/inspector_notifier.dart`）にある、イベントバースト時の描画のもたつきにつながる2つのホットパスを解消します。

- Refs #94

## 変更内容

1. **イベントリストの構築を単一パス化**（L738付近）: 従来は `List.from(_state.events)`（全コピー、O(n)）してから `insert(0, newEvent)`（要素シフト、さらに O(n)）という2パスでした。新しいリストを最終サイズで直接確保し、1回のループで詰め直すことで、1イベントあたりの作業量を約半分に削減しました。挙動（新しい順の並び、`_maxEventCount`（1000件）を超えた分の退避、退避イベントの `expandedEventIds`/`comparedEventIds` からの除去）は変更していません。

2. **providerStats 再計算のスロットル**: `computeProviderStats` はイベント全件走査 + provider ごとのソートを行うため、高頻度 provider のバースト中は毎イベントでフルコンピュートされていました。stats キャッシュの無効化を最大250msに1回まで間引き、無効化を見送った場合はトレーリングタイマーで250ms後に確定無効化+再描画するようにしました（バーストが収まった直後の最終状態が古いまま固定されることを防止）。

## 変更していないこと

- イベントの並び順・表示仕様・MCP側の挙動は一切変更していません。
- `_subscribeToEvents` の実イベントストリーム経路（vm_service 接続が必要）は既存同様ユニットテスト対象外です（テストファイル内の既存コメント "which is complex for this scope" の通り）。

## テスト

`inspector_notifier_test.dart` に `providerStats throttling` グループを追加:
- 初回の stats 反映は即座に行われることを確認。
- スロットル窓内に連続して events が更新されても、トレーリングタイマー経過後には最新の値に反映されることを確認（イベントが握りつぶされないことの固定）。

**注記:** 作業環境に Dart/Flutter SDK が無く、ローカル実行はできていません。本 PR の CI（`flutter analyze` + `flutter test`）が実行検証します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016GUw4HaKk7g5q2onZocydw)_