### PR TITLE
refactor: unify lenient int coercion; guard stats duplication drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,9 @@ so a rule change must be made in both places or the UI and MCP will disagree:
 | Event model    | serialized in `observer.dart` / `utils/serialization.dart` | `lib/src/models/provider_event.dart`, `provider_info.dart` |
 
 When you change stats thresholds or the event shape, **grep both packages.**
+A drift guard (`test/provider_stats_sync_test.dart` in the main package)
+machine-checks that the shared stats constants and the sparkline bucketing
+function stay identical across the two copies.
 
 ## Wire format is an implicit contract across THREE places
 

--- a/packages/riverpod_devtools/lib/src/http_server_io.dart
+++ b/packages/riverpod_devtools/lib/src/http_server_io.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 import 'graph_builder.dart';
 import 'mcp_constants.dart';
 import 'provider_stats.dart';
+import 'utils/coerce_int.dart';
 
 class RiverpodDevToolsHttpServer {
   RiverpodDevToolsHttpServer({int maxBufferSize = 1000})
@@ -231,7 +232,7 @@ class RiverpodDevToolsHttpServer {
           // Accept "50" and "50.0" (some clients format integers as
           // doubles); reject anything else explicitly instead of silently
           // returning the full buffer.
-          limit = int.tryParse(rawLimit) ?? num.tryParse(rawLimit)?.toInt();
+          limit = coerceInt(rawLimit);
           if (limit == null || limit < 0) {
             request.response
               ..statusCode = 400
@@ -245,7 +246,7 @@ class RiverpodDevToolsHttpServer {
         for (final name in const ['since', 'until']) {
           final raw = params[name];
           if (raw == null) continue;
-          final parsed = int.tryParse(raw) ?? num.tryParse(raw)?.toInt();
+          final parsed = coerceInt(raw);
           if (parsed == null) {
             request.response
               ..statusCode = 400

--- a/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
+++ b/packages/riverpod_devtools/lib/src/mcp/riverpod_devtools_mcp_server.dart
@@ -5,6 +5,7 @@ import 'dart:io' as io;
 import 'package:dart_mcp/server.dart';
 
 import '../mcp_constants.dart';
+import '../utils/coerce_int.dart';
 import 'app_discovery_cache.dart';
 import 'compact.dart';
 
@@ -275,15 +276,15 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
       // dart_mcp validates arguments against the schema before this runs,
       // rejecting strings and fractional numbers — but whole doubles
       // (e.g. 50.0, as some clients encode integers) pass validation and
-      // arrive here as num, so normalize via toInt().
-      if (arguments['limit'] case final num limit) 'limit': '${limit.toInt()}',
+      // arrive here as num, so normalize via coerceInt.
+      if (coerceInt(arguments['limit']) case final int limit) 'limit': '$limit',
       if (arguments['provider'] case final String provider
           when provider.isNotEmpty)
         'provider': provider,
       if (arguments['type'] case final String type when type.isNotEmpty)
         'type': type,
-      if (arguments['since'] case final num since) 'since': '${since.toInt()}',
-      if (arguments['until'] case final num until) 'until': '${until.toInt()}',
+      if (coerceInt(arguments['since']) case final int since) 'since': '$since',
+      if (coerceInt(arguments['until']) case final int until) 'until': '$until',
     };
     final view = arguments['view'] as String? ?? 'compact';
     return _request(
@@ -448,8 +449,8 @@ base class RiverpodDevToolsMcpServer extends MCPServer with ToolsSupport {
   ///
   /// Returns `(port, null)` on success or `(null, errorResult)` otherwise.
   Future<(int?, CallToolResult?)> _resolvePort(CallToolRequest request) async {
-    if ((request.arguments ?? const {})['port'] case final num port) {
-      return (port.toInt(), null);
+    if (coerceInt((request.arguments ?? const {})['port']) case final int port) {
+      return (port, null);
     }
 
     final apps = await _discoveryCache.get();

--- a/packages/riverpod_devtools/lib/src/utils/coerce_int.dart
+++ b/packages/riverpod_devtools/lib/src/utils/coerce_int.dart
@@ -1,0 +1,17 @@
+/// Coerces a value that should be an integer but may arrive in a client-quirk
+/// form: an `int`, a whole-numbered `double` (some MCP/HTTP clients encode
+/// integers as doubles, e.g. `50.0`), or the string form of either
+/// (`"50"`, `"50.0"` in query parameters).
+///
+/// Returns null when the value is absent or not numeric. This is the single
+/// definition of that leniency — the MCP server (JSON arguments) and the
+/// in-app HTTP server (query strings) both route through it so the two layers
+/// can't drift apart.
+int? coerceInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) {
+    return int.tryParse(value) ?? num.tryParse(value)?.toInt();
+  }
+  return null;
+}

--- a/packages/riverpod_devtools/test/coerce_int_test.dart
+++ b/packages/riverpod_devtools/test/coerce_int_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_devtools/src/utils/coerce_int.dart';
+
+void main() {
+  group('coerceInt', () {
+    test('passes an int through', () {
+      expect(coerceInt(50), 50);
+      expect(coerceInt(0), 0);
+      expect(coerceInt(-3), -3);
+    });
+
+    test('coerces a whole-numbered double (client quirk)', () {
+      expect(coerceInt(50.0), 50);
+    });
+
+    test('truncates a fractional double (matches num.toInt())', () {
+      // Pre-existing behavior of both call sites; fractional values are
+      // normally rejected upstream (MCP schema validation) before reaching
+      // this helper.
+      expect(coerceInt(50.7), 50);
+    });
+
+    test('parses integer and double strings (query parameters)', () {
+      expect(coerceInt('50'), 50);
+      expect(coerceInt('50.0'), 50);
+      expect(coerceInt('-3'), -3);
+    });
+
+    test('returns null for non-numeric input', () {
+      expect(coerceInt(null), isNull);
+      expect(coerceInt('abc'), isNull);
+      expect(coerceInt(''), isNull);
+      expect(coerceInt(true), isNull);
+      expect(coerceInt([50]), isNull);
+    });
+  });
+}

--- a/packages/riverpod_devtools/test/provider_stats_sync_test.dart
+++ b/packages/riverpod_devtools/test/provider_stats_sync_test.dart
@@ -1,0 +1,84 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// Drift guard for the deliberately duplicated stats logic.
+///
+/// The stats aggregation is implemented twice on purpose — this package
+/// aggregates raw event JSON for `/stats` + MCP, while the DevTools extension
+/// aggregates its typed `ProviderEvent` model for the UI (the two packages
+/// don't share code; see CLAUDE.md). The *rules* must stay identical, or the
+/// UI and MCP will disagree about the same app.
+///
+/// This test machine-checks the parts that are textually shared between the
+/// two files — the threshold/window constants and the sparkline bucketing
+/// function — without introducing a dependency between the packages. If it
+/// fails, someone changed one side only: apply the same change to the other
+/// file (or update this test if the shapes legitimately diverged).
+void main() {
+  const packageFile = 'lib/src/provider_stats.dart';
+  const extensionFile =
+      '../riverpod_devtools_extension/lib/src/utils/provider_stats.dart';
+
+  group('provider_stats duplication drift guard', () {
+    test('the extension copy exists where this guard expects it', () {
+      expect(
+        File(extensionFile).existsSync(),
+        isTrue,
+        reason:
+            'The extension-side stats implementation moved. Update the paths '
+            'in this drift guard so it keeps comparing the two copies.',
+      );
+    });
+
+    test('shared constants are identical in both copies', () {
+      final packageConsts = _constants(File(packageFile).readAsStringSync());
+      final extensionConsts =
+          _constants(File(extensionFile).readAsStringSync());
+
+      // Every constant defined on either side must exist on both sides with
+      // the same value (thresholds/windows drive the flags users see).
+      expect(packageConsts.keys.toSet(), extensionConsts.keys.toSet());
+      expect(packageConsts, extensionConsts);
+      expect(packageConsts, isNotEmpty);
+    });
+
+    test('the sparkline bucketing function is identical in both copies', () {
+      final packageFn =
+          _function(File(packageFile).readAsStringSync(), '_addToBucket');
+      final extensionFn =
+          _function(File(extensionFile).readAsStringSync(), '_addToBucket');
+
+      expect(packageFn, isNotNull);
+      expect(extensionFn, isNotNull);
+      expect(packageFn, extensionFn);
+    });
+  });
+}
+
+/// Extracts top-level `const kName = value;` declarations as a name → value
+/// map, with the value normalized (comments/whitespace stripped) so only a
+/// semantic change trips the guard.
+Map<String, String> _constants(String source) {
+  final pattern = RegExp(r'^const\s+(k\w+)\s*=\s*([^;]+);', multiLine: true);
+  return {
+    for (final match in pattern.allMatches(_stripComments(source)))
+      match.group(1)!: _normalize(match.group(2)!),
+  };
+}
+
+/// Extracts the body of top-level function [name] (from its `void name`
+/// declaration to the first unindented closing brace), normalized for
+/// comparison. Returns null when not found.
+String? _function(String source, String name) {
+  final start = source.indexOf('void $name');
+  if (start == -1) return null;
+  final end = source.indexOf('\n}', start);
+  if (end == -1) return null;
+  return _normalize(_stripComments(source.substring(start, end + 2)));
+}
+
+String _stripComments(String source) =>
+    source.replaceAll(RegExp(r'//[^\n]*'), '');
+
+String _normalize(String source) => source.replaceAll(RegExp(r'\s+'), ' ').trim();


### PR DESCRIPTION
## 概要

issue #95 の再検討結果(issue コメント参照)を受けた PR です。**stats 実装の共有化は取り下げ**（二重実装は入力・出力モデルが異なる構造的なもので、共有はパス依存による解決リスクかアダプタ層の増加しか生まない）、代わりに同 issue の中で**結合コストゼロで拾える2断片**だけを実施します。

- Refs #95（クローズ済み・判断根拠は issue コメントに記載）

## 変更内容

### 1. num→int 変換の統一（`coerceInt`）

「整数が int / 整数値 double（`50.0`）/ その文字列形（`"50"`, `"50.0"`）のどれで届くか分からない」というクライアント互換の扱いが、MCP サーバー（JSON 引数）と in-app HTTP サーバー（クエリ文字列）に別々に書かれていました。`lib/src/utils/coerce_int.dart` の `coerceInt` を単一定義とし、両層（HTTP: `limit`/`since`/`until`、MCP: `limit`/`since`/`until`/`port`）をそこに寄せました。**挙動は完全に保存**しています（num は `toInt()`、文字列は `int.tryParse ?? num.tryParse()?.toInt()` と同値）。

### 2. stats 二重実装の drift ガードテスト

2つの `provider_stats.dart` は意図的に別実装のままですが、**テキストとして共有されている部分**（しきい値・ウィンドウの5定数と、スパークラインの `_addToBucket` 関数）が食い違うと「DevTools の表示と MCP の判定がズレる」事故になります。monorepo である事実を利用し、package 側のテスト（`test/provider_stats_sync_test.dart`）が隣接パッケージのソースを読み、正規化テキスト比較で同期を機械検証します。**パッケージ間に依存は張りません**。片側だけ変更すると CI が落ち、メッセージが「もう片方にも同じ変更を」と誘導します。

### 3. CLAUDE.md

既存の「grep both packages」ルールの直後に、drift ガードの存在を1文追記。

## テスト

- `coerce_int_test.dart`: int 素通し / 整数値 double / 小数 double の切り捨て（既存挙動の固定） / 文字列形 / 非数値は null。
- `provider_stats_sync_test.dart`: extension 側ファイルの存在、共有定数の一致、`_addToBucket` の一致。

**注記:** 作業環境に Dart/Flutter SDK が無くローカル実行はできていません。CI が検証します。drift ガードの抽出ロジック（定数の正規表現、関数末尾 `\n}` の検出）は両実ファイルと手動照合済みで、現状のファイルでは全テストが成立する構成です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AdVpiY5yHAWVXYQAdCyLms)_