### PR TITLE
fix: detect @riverpod code-generated providers in the static analyzer

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+- **Fix: `dart run riverpod_devtools:analyze` now detects `@riverpod`
+  code-generated providers.** The analyzer previously only recognized
+  hand-written `final xProvider = SomeProvider(...)` top-level declarations.
+  Apps using `riverpod_generator` (`@riverpod` functions/classes) got zero
+  matching static metadata for those providers — even though
+  `riverpod_dependencies.json` loaded successfully, every runtime event for
+  them reported `dependenciesSource: 'name_mismatch'`, since the generated
+  provider variable (in the excluded `.g.dart` file) never appeared in the
+  analyzer's output. `@riverpod`/`@Riverpod(...)`-annotated functions and
+  classes are now recognized in the *source* file, and named using
+  `riverpod_generator`'s own convention (`<lowerCamelCase(name)>Provider`),
+  so their static dependencies attach correctly at runtime.
 - **Docs: MCP setup for monorepo / subdirectory / FVM Flutter apps.** `MCP.md`
   now documents the shell-wrapper `.mcp.json` config needed when the Flutter
   package (the one depending on `riverpod_devtools`) lives below the

--- a/packages/riverpod_devtools/TROUBLESHOOTING.md
+++ b/packages/riverpod_devtools/TROUBLESHOOTING.md
@@ -108,6 +108,8 @@
 **Possible Causes**:
 - JSON was loaded, but the runtime provider name does not exactly match any entry in the JSON file (case-sensitive)
 - Analyzer was run against a different codebase than the running app
+- `riverpod_dependencies.json` is stale — regenerated after the analyzer gained
+  `@riverpod` code-generation support (see below) but not re-run since
 
 **Solutions**:
 
@@ -124,6 +126,18 @@
 3. Debug registered provider names:
    ```dart
    print(RiverpodDevToolsRegistry.instance.allProviderNames);
+   ```
+
+4. If **every** (or nearly every) provider reports `name_mismatch` even though
+   `riverpod_dependencies.json` loaded and setup otherwise looks correct, and
+   your app uses `@riverpod` code generation (`riverpod_generator`), make sure
+   you're on a `riverpod_devtools` version that detects annotated providers —
+   older analyzer versions only recognized hand-written
+   `final xProvider = Provider(...)` declarations, so a codegen-heavy app got
+   effectively no static metadata for its `@riverpod` functions/classes.
+   Re-run the analyzer after upgrading:
+   ```bash
+   dart run riverpod_devtools:analyze
    ```
 
 ## General DevTools Issues

--- a/packages/riverpod_devtools/lib/src/cli/analyzer.dart
+++ b/packages/riverpod_devtools/lib/src/cli/analyzer.dart
@@ -103,7 +103,7 @@ class RiverpodAnalyzer {
       if (context.contextRoot.isAnalyzed(file.path)) {
         final result = await context.currentSession.getResolvedUnit(file.path);
         if (result is ResolvedUnitResult) {
-          final visitor = _ProviderVisitor(file.path);
+          final visitor = ProviderVisitor(file.path);
           result.unit.visitChildren(visitor);
           metadata.addAll(visitor.providers);
         }
@@ -154,11 +154,17 @@ class RiverpodAnalyzer {
   }
 }
 
-class _ProviderVisitor extends RecursiveAstVisitor<void> {
+/// Walks a compilation unit collecting [ProviderMetadata] for every provider
+/// declaration it recognizes. Public (rather than the usual analyzer-private
+/// helper) so tests can drive it directly off an unresolved `parseString()`
+/// unit, the same way [SimpleDependencyExtractor] is tested — a full
+/// [AnalysisContextCollection] needs a resolvable SDK, which test
+/// environments don't always have.
+class ProviderVisitor extends RecursiveAstVisitor<void> {
   final String filePath;
   final List<ProviderMetadata> providers = [];
 
-  _ProviderVisitor(this.filePath);
+  ProviderVisitor(this.filePath);
 
   @override
   void visitTopLevelVariableDeclaration(TopLevelVariableDeclaration node) {
@@ -197,6 +203,105 @@ class _ProviderVisitor extends RecursiveAstVisitor<void> {
     }
 
     super.visitTopLevelVariableDeclaration(node);
+  }
+
+  // `@riverpod` code generation (riverpod_generator) never declares a
+  // top-level `final xProvider = ...` in the *source* file — the generated
+  // variable lives in the `.g.dart` file, which is intentionally excluded
+  // from analysis (it's derived, not authored). Without these two visitors,
+  // every annotated provider/notifier is invisible to the analyzer, so its
+  // generated name (`<lowerCamelCase(name)>Provider`, per riverpod_generator's
+  // own convention) never appears in riverpod_dependencies.json — the runtime
+  // provider then reports 'name_mismatch' even though nothing is misconfigured.
+  @override
+  void visitFunctionDeclaration(FunctionDeclaration node) {
+    if (_hasRiverpodAnnotation(node.metadata)) {
+      _addAnnotatedProvider(
+        offsetNode: node,
+        name: _generatedProviderName(node.name.lexeme),
+        providerType: _inferFunctionProviderType(node),
+        dependencySource: node.functionExpression.body,
+      );
+    }
+    super.visitFunctionDeclaration(node);
+  }
+
+  @override
+  void visitClassDeclaration(ClassDeclaration node) {
+    if (_hasRiverpodAnnotation(node.metadata)) {
+      _addAnnotatedProvider(
+        offsetNode: node,
+        name: _generatedProviderName(node.name.lexeme),
+        providerType: _inferClassProviderType(node),
+        dependencySource: node,
+      );
+    }
+    super.visitClassDeclaration(node);
+  }
+
+  void _addAnnotatedProvider({
+    required AstNode offsetNode,
+    required String name,
+    required String providerType,
+    required AstNode dependencySource,
+  }) {
+    final compilationUnit = offsetNode.thisOrAncestorOfType<CompilationUnit>();
+    if (compilationUnit == null) return;
+
+    final lineInfo = compilationUnit.lineInfo;
+    final dependencies = SimpleDependencyExtractor.extractDependencies(
+      dependencySource,
+      filePath,
+      lineInfo,
+    );
+
+    final location = lineInfo.getLocation(offsetNode.offset);
+    providers.add(ProviderMetadata(
+      name: name,
+      providerType: providerType,
+      dependencies: dependencies,
+      location: SourceLocation(
+        file: filePath,
+        line: location.lineNumber,
+        column: location.columnNumber,
+      ),
+    ));
+  }
+
+  /// `@riverpod`/`@Riverpod(...)` — matched by name only (not the resolved
+  /// element), same lightweight approach as the rest of this AST-only
+  /// analyzer (no resolved imports, no build_runner dependency).
+  bool _hasRiverpodAnnotation(NodeList<Annotation> metadata) {
+    for (final annotation in metadata) {
+      final name = annotation.name.name;
+      if (name == 'riverpod' || name == 'Riverpod') return true;
+    }
+    return false;
+  }
+
+  /// riverpod_generator's naming convention: the function/class name with
+  /// its first letter lower-cased, plus a `Provider` suffix.
+  String _generatedProviderName(String sourceName) {
+    if (sourceName.isEmpty) return 'Provider';
+    return '${sourceName[0].toLowerCase()}${sourceName.substring(1)}Provider';
+  }
+
+  String _inferFunctionProviderType(FunctionDeclaration node) {
+    final returnType = node.returnType?.toString() ?? '';
+    if (returnType.startsWith('Stream')) return 'StreamProvider';
+    if (returnType.startsWith('Future')) return 'FutureProvider';
+    return 'Provider';
+  }
+
+  String _inferClassProviderType(ClassDeclaration node) {
+    for (final member in node.members) {
+      if (member is MethodDeclaration && member.name.lexeme == 'build') {
+        final returnType = member.returnType?.toString() ?? '';
+        if (returnType.startsWith('Stream')) return 'StreamNotifierProvider';
+        if (returnType.startsWith('Future')) return 'AsyncNotifierProvider';
+      }
+    }
+    return 'NotifierProvider';
   }
 
   String? _getProviderType(Expression expression) {

--- a/packages/riverpod_devtools/lib/src/cli/analyzer.dart
+++ b/packages/riverpod_devtools/lib/src/cli/analyzer.dart
@@ -229,12 +229,15 @@ class ProviderVisitor extends RecursiveAstVisitor<void> {
   @override
   void visitClassDeclaration(ClassDeclaration node) {
     if (_hasRiverpodAnnotation(node.metadata)) {
-      _addAnnotatedProvider(
-        offsetNode: node,
-        name: _generatedProviderName(node.name.lexeme),
-        providerType: _inferClassProviderType(node),
-        dependencySource: node,
-      );
+      final className = _classNameOf(node);
+      if (className != null) {
+        _addAnnotatedProvider(
+          offsetNode: node,
+          name: _generatedProviderName(className),
+          providerType: _inferClassProviderType(node),
+          dependencySource: node,
+        );
+      }
     }
     super.visitClassDeclaration(node);
   }
@@ -293,8 +296,45 @@ class ProviderVisitor extends RecursiveAstVisitor<void> {
     return 'Provider';
   }
 
+  // `ClassDeclaration.name`/`.members` moved across analyzer versions — older
+  // releases expose them directly, a newer one (tracking Dart's primary
+  // constructors preview) nests them under `namePart.typeName` /
+  // `body.members` instead. `analyzer`'s constraint here is deliberately wide
+  // (`>=6.0.0 <15.0.0`), so resolve both shapes dynamically at runtime rather
+  // than picking one statically, the same way observer.dart bridges Riverpod
+  // API differences across versions.
+  String? _classNameOf(ClassDeclaration node) {
+    final dynamic dynNode = node;
+    try {
+      // ignore: avoid_dynamic_calls
+      return dynNode.name.lexeme as String;
+    } catch (_) {
+      try {
+        // ignore: avoid_dynamic_calls
+        return dynNode.namePart.typeName.lexeme as String;
+      } catch (_) {
+        return null;
+      }
+    }
+  }
+
+  Iterable<dynamic> _classMembersOf(ClassDeclaration node) {
+    final dynamic dynNode = node;
+    try {
+      // ignore: avoid_dynamic_calls
+      return dynNode.members as Iterable<dynamic>;
+    } catch (_) {
+      try {
+        // ignore: avoid_dynamic_calls
+        return dynNode.body.members as Iterable<dynamic>;
+      } catch (_) {
+        return const [];
+      }
+    }
+  }
+
   String _inferClassProviderType(ClassDeclaration node) {
-    for (final member in node.members) {
+    for (final member in _classMembersOf(node)) {
       if (member is MethodDeclaration && member.name.lexeme == 'build') {
         final returnType = member.returnType?.toString() ?? '';
         if (returnType.startsWith('Stream')) return 'StreamNotifierProvider';

--- a/packages/riverpod_devtools/lib/src/cli/simple_dependency_extractor.dart
+++ b/packages/riverpod_devtools/lib/src/cli/simple_dependency_extractor.dart
@@ -7,9 +7,11 @@ import '../static_dependencies.dart';
 
 /// Simplified dependency extractor for CLI use (no build_runner dependency)
 class SimpleDependencyExtractor {
-  /// Extract dependencies from a provider initializer expression
+  /// Extract dependencies from a provider initializer expression, or from
+  /// any other AST node containing `ref.watch`/`read`/`listen` calls (e.g. a
+  /// `@riverpod` function body or an annotated notifier class).
   static List<DependencyInfo> extractDependencies(
-    Expression initializer,
+    AstNode initializer,
     String filePath,
     LineInfo lineInfo,
   ) {

--- a/packages/riverpod_devtools/test/cli_riverpod_annotation_test.dart
+++ b/packages/riverpod_devtools/test/cli_riverpod_annotation_test.dart
@@ -1,0 +1,133 @@
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:riverpod_devtools/src/builder/provider_metadata.dart';
+import 'package:riverpod_devtools/src/cli/analyzer.dart';
+
+/// [ProviderVisitor] normally runs against a resolved AnalysisContextCollection
+/// unit (via `RiverpodAnalyzer.analyze()`), which needs an SDK to resolve
+/// against. It only does syntactic AST matching though (same as
+/// [SimpleDependencyExtractor]), so an unresolved `parseString()` unit is
+/// enough to exercise it directly.
+List<ProviderMetadata> _providersFor(String source) {
+  final parsed = parseString(content: source, throwIfDiagnostics: false);
+  final visitor = ProviderVisitor('lib/test.dart');
+  parsed.unit.visitChildren(visitor);
+  return visitor.providers;
+}
+
+void main() {
+  group('ProviderVisitor - @riverpod function-based providers', () {
+    test('names a function-based provider per riverpod_generator convention', () {
+      final providers = _providersFor('''
+@riverpod
+String greeting(GreetingRef ref) => 'hi';
+''');
+
+      expect(providers, hasLength(1));
+      expect(providers.single.name, 'greetingProvider');
+      expect(providers.single.providerType, 'Provider');
+    });
+
+    test('recognizes the @Riverpod(...) constructor form', () {
+      final providers = _providersFor('''
+@Riverpod(keepAlive: true)
+String greeting(GreetingRef ref) => 'hi';
+''');
+
+      expect(providers, hasLength(1));
+      expect(providers.single.name, 'greetingProvider');
+    });
+
+    test('infers FutureProvider/StreamProvider from the return type', () {
+      final providers = _providersFor('''
+@riverpod
+Future<String> asyncGreeting(AsyncGreetingRef ref) async => 'hi';
+
+@riverpod
+Stream<int> tick(TickRef ref) async* {}
+''');
+
+      expect(providers, hasLength(2));
+      expect(providers[0].providerType, 'FutureProvider');
+      expect(providers[1].providerType, 'StreamProvider');
+    });
+
+    test('extracts ref.watch/read/listen calls from the function body', () {
+      final providers = _providersFor('''
+@riverpod
+String greeting(GreetingRef ref) {
+  final name = ref.watch(nameProvider);
+  ref.listen(loggerProvider, (prev, next) {});
+  return name;
+}
+''');
+
+      expect(providers.single.dependencies.map((d) => d.providerName),
+          containsAll(['nameProvider', 'loggerProvider']));
+    });
+
+    test('a plain (non-annotated) function is not treated as a provider', () {
+      final providers = _providersFor('String greeting() => \'hi\';');
+      expect(providers, isEmpty);
+    });
+  });
+
+  group('ProviderVisitor - @riverpod class-based (notifier) providers', () {
+    test('names a class-based provider from the lower-camel class name', () {
+      final providers = _providersFor('''
+@riverpod
+class VersionManager extends _\$VersionManager {
+  @override
+  int build() => 0;
+}
+''');
+
+      expect(providers, hasLength(1));
+      expect(providers.single.name, 'versionManagerProvider');
+      expect(providers.single.providerType, 'NotifierProvider');
+    });
+
+    test('infers AsyncNotifierProvider/StreamNotifierProvider from build()', () {
+      final providers = _providersFor('''
+@riverpod
+class Facility extends _\$Facility {
+  @override
+  Future<int> build() async => 0;
+}
+
+@riverpod
+class FacilityTicker extends _\$FacilityTicker {
+  @override
+  Stream<int> build() async* {}
+}
+''');
+
+      expect(providers, hasLength(2));
+      expect(providers[0].providerType, 'AsyncNotifierProvider');
+      expect(providers[1].providerType, 'StreamNotifierProvider');
+    });
+
+    test('extracts ref.watch calls from anywhere in the class body', () {
+      final providers = _providersFor('''
+@riverpod
+class VersionManager extends _\$VersionManager {
+  @override
+  int build() {
+    return ref.watch(configProvider);
+  }
+}
+''');
+
+      expect(providers.single.dependencies.single.providerName, 'configProvider');
+    });
+
+    test('a plain (non-annotated) class is not treated as a provider', () {
+      final providers = _providersFor('''
+class VersionManager {
+  int build() => 0;
+}
+''');
+      expect(providers, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes #105.

The static dependency analyzer (`dart run riverpod_devtools:analyze`) only recognized hand-written top-level `final xProvider = SomeProvider(...)` declarations. Apps using `riverpod_generator` (`@riverpod` functions/classes — the setup implied by the reporter's `riverpod_annotation` dependency) got **zero** matching static metadata for those providers: the generated provider variable lives in the excluded `.g.dart` file, so it never showed up in `riverpod_dependencies.json` under a name the runtime could match. Every runtime event for those providers then reported `dependenciesSource: 'name_mismatch'`, even though the JSON loaded fine and setup was otherwise correct — exactly the symptom in the issue (0 exact matches across 1000 sampled events).

## Fix

`@riverpod` / `@Riverpod(...)`-annotated top-level functions and classes are now detected directly in the *source* file (not the generated `.g.dart`), and named using `riverpod_generator`'s own convention: `<lowerCamelCase(function/class name)>Provider`. Dependencies (`ref.watch`/`read`/`listen`) are extracted from the function body / class body the same way they already are for hand-written providers.

- `lib/src/cli/analyzer.dart`: `ProviderVisitor` (renamed from `_ProviderVisitor` — see below) gained `visitFunctionDeclaration` / `visitClassDeclaration` handling, plus small helpers for the naming convention and provider-type inference (Provider/FutureProvider/StreamProvider for functions; NotifierProvider/AsyncNotifierProvider/StreamNotifierProvider for classes, inferred from `build()`'s return type).
- `lib/src/cli/simple_dependency_extractor.dart`: widened `extractDependencies`'s parameter from `Expression` to `AstNode` (a superset — existing call sites are unaffected) so it can also be pointed at a function/class body.
- `ProviderVisitor` is now public instead of private, so it can be driven directly off an unresolved `parseString()` unit in tests — mirroring how `SimpleDependencyExtractor` is already tested — without needing a resolvable `AnalysisContextCollection`/SDK.
- Added `test/cli_riverpod_annotation_test.dart` covering: function- and class-based provider naming, the `@Riverpod(...)` constructor form, provider-type inference from return types, dependency extraction from annotated bodies, and that non-annotated declarations are correctly ignored.
- Documented the fix in `CHANGELOG.md` (Unreleased) and added a troubleshooting entry to `TROUBLESHOOTING.md`'s "Provider Name Mismatch" section for the "every provider mismatches" symptom.

## Test plan

- [ ] `flutter test` in `packages/riverpod_devtools` (this sandbox has no Flutter/Dart SDK, so I could not run this myself — please verify `test/cli_riverpod_annotation_test.dart` and the existing suite pass)
- [ ] `flutter analyze` in `packages/riverpod_devtools`
- [ ] Optional manual check: run `dart run riverpod_devtools:analyze` against a Riverpod app using `@riverpod` codegen and confirm `riverpod_dependencies.json` now contains entries for those providers, matching the running app's provider names (`dependenciesSource: 'static'` instead of `'name_mismatch'`)

No UI changes in this PR (analyzer/backend only), so no extension screenshot is needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7RBZhMbgazKMNFeZ5yfqN)_