### PR TITLE
docs: add MCP connection diagnostic checklist and client-reload guidance

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -5,6 +5,14 @@
   package (the one depending on `riverpod_devtools`) lives below the
   directory `.mcp.json` is read from — a common monorepo layout — including
   an FVM example (`fvm dart run ...`).
+- **Docs: MCP connection diagnostics.** `TROUBLESHOOTING.md`'s MCP Issues
+  section now leads with a quick diagnostic checklist (debug mode, observer
+  registered, `curl .../ping` health check with the expected response shape,
+  running from the right package directory, MCP client restarted after
+  `.mcp.json` changes) so a broken setup can be isolated to app-side vs.
+  MCP-client-side without guesswork. `MCP.md` now calls out that most MCP
+  clients only read `.mcp.json` at startup, so tools added mid-session need a
+  client restart/reload.
 
 ## 1.1.0
 

--- a/packages/riverpod_devtools/MCP.md
+++ b/packages/riverpod_devtools/MCP.md
@@ -68,6 +68,8 @@ This works the same way as `dart run riverpod_devtools:analyze` — no path need
 >
 > If your MCP client supports a separate working-directory field, prefer setting that over the shell wrapper — check its docs, since this varies by client.
 
+> **New or changed `.mcp.json` mid-session?** Most MCP clients (including Claude Code) only read `.mcp.json` at startup. If you add or edit it while a session is already running, restart or reload the client — the new tools won't appear otherwise. See [Troubleshooting](#troubleshooting) if tools are still missing after that.
+
 > **First launch is slow (one-time):** `dart run` compiles the MCP server the first time it starts, which can take ~10–20 seconds before the server responds — some MCP clients may report a startup timeout on that very first attempt. Just retry (or restart your AI tool): subsequent launches reuse the compiled snapshot and start in well under a second. The compile messages go to stderr, so they never interfere with the MCP protocol on stdout. The snapshot is rebuilt after `flutter pub get` / dependency changes.
 
 **2. Run your Flutter app in debug mode**

--- a/packages/riverpod_devtools/TROUBLESHOOTING.md
+++ b/packages/riverpod_devtools/TROUBLESHOOTING.md
@@ -166,6 +166,49 @@
 
 ## MCP Issues
 
+### Quick diagnostic checklist
+
+When an MCP tool (`get_riverpod_logs`, `get_provider_state`, etc.) isn't
+available or isn't returning what you expect, work through these in order —
+each one isolates a different part of the setup:
+
+1. Is the Flutter app running in **debug mode** (`flutter run`)? The HTTP
+   server never starts in profile/release builds, or on web.
+2. Is `RiverpodDevToolsObserver()` registered in
+   `ProviderScope(observers: [...])`?
+3. Is the app-side HTTP server reachable? Query it directly, bypassing MCP
+   entirely:
+   ```bash
+   curl http://127.0.0.1:8788/ping
+   ```
+   A healthy response looks like:
+   ```json
+   {"riverpodDevtools": true, "port": 8788, "providerCount": 86, "eventCount": 1000}
+   ```
+   If this fails, the problem is on the app side (steps 1–2) or the port —
+   each debug app binds the first free port in `8788`–`8797`, so retry with
+   `8789`, `8790`, etc. if several apps are running.
+4. Does the MCP command run **from the Flutter package directory** — the one
+   whose `pubspec.yaml` lists `riverpod_devtools`? See
+   [MCP.md's monorepo/subdirectory note](MCP.md#setup) if `.mcp.json` lives
+   above that directory.
+5. Has the MCP client been **restarted or reloaded** since `.mcp.json` was
+   added or changed? Most MCP clients, including Claude Code, only read
+   `.mcp.json` at session/client startup — adding or editing it mid-session
+   does not make new tools appear until you restart. If `/ping` (step 3)
+   succeeds but the tools still aren't available in your AI tool, this is the
+   most likely cause.
+
+If `/ping` works but you still need to inspect state immediately without
+restarting, the other endpoints (`/logs`, `/providers`, `/graph`, `/stats`)
+are reachable the same way as a stopgap:
+```bash
+curl http://127.0.0.1:8788/logs
+curl http://127.0.0.1:8788/providers
+curl http://127.0.0.1:8788/stats
+curl http://127.0.0.1:8788/graph
+```
+
 ### AI tool reports "No running Flutter app ... was found on ports 8788–8797"
 
 The MCP server probes `localhost:8788`–`8797` and found nothing. Check, in order:


### PR DESCRIPTION
## Summary

Fixes #107.

After adding `.mcp.json` mid-session, the reporter found the MCP tools weren't available even though the app-side setup (observer registered, HTTP server running, `/ping` reachable) was correct — and there was no documented way to tell "MCP client hasn't reloaded" apart from "app-side isn't running" or "wrong working directory."

## Change

- `TROUBLESHOOTING.md`: MCP Issues now opens with a **quick diagnostic checklist** (before the existing per-symptom subsections) that walks through, in order: debug mode → observer registered → `curl http://127.0.0.1:8788/ping` health check (with the expected response shape) → running from the correct package directory (linking to the monorepo note) → MCP client restarted since `.mcp.json` changed. It also lists the direct `/logs` `/providers` `/stats` `/graph` curl commands as a stopgap for inspecting state without waiting on the MCP client.
- `MCP.md`: added a callout in the Setup section noting that most MCP clients (including Claude Code) only read `.mcp.json` at startup, so tools added mid-session require a restart/reload — this is very likely what the reporter hit.
- `CHANGELOG.md`: Unreleased entry.

## Test plan

Docs-only change — no code paths affected, no UI change (no extension screenshot needed).
- [ ] Skim `TROUBLESHOOTING.md` / `MCP.md` rendering for the new sections' formatting/links.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7RBZhMbgazKMNFeZ5yfqN)_