### PR TITLE
fix: sanitize non-finite numbers so the observer never crashes postEvent

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Unreleased
 
+- **Fix: non-finite numbers no longer crash the observer.** A provider value
+  containing `double.infinity`, `double.negativeInfinity`, or `double.nan`
+  could throw an uncaught `Converting object to an encodable object failed:
+  Infinity` from `developer.postEvent`, because those are valid `num`s that
+  Dart's `json.encode` (with no `toEncodable` fallback) rejects. Both routes
+  that let a non-finite number reach the payload are now sealed: the
+  `toJson()` sanitizer (`_jsonSafe`) rewrites non-finite doubles to their
+  string form (`"Infinity"`/`"-Infinity"`/`"NaN"`), and the `toString()`
+  parser no longer turns `num.tryParse('Infinity')` into a live non-finite
+  double (it keeps the original string). Finite numbers are unaffected.
 - **Fix: `dart run riverpod_devtools:analyze` now detects `@riverpod`
   code-generated providers.** The analyzer previously only recognized
   hand-written `final xProvider = SomeProvider(...)` top-level declarations.

--- a/packages/riverpod_devtools/lib/src/utils/serialization.dart
+++ b/packages/riverpod_devtools/lib/src/utils/serialization.dart
@@ -178,7 +178,15 @@ void _markTruncated(Map<String, Object?> result, int total, int maxItems) {
 /// cannot handle (DateTime, enums, custom objects) to its toString() form.
 Object? _jsonSafe(Object? value, int depth) {
   const maxDepth = 10;
-  if (value == null || value is num || value is bool || value is String) {
+  if (value is num) {
+    // Non-finite doubles (Infinity/-Infinity/NaN) are valid `num`s but
+    // json.encode — used by developer.postEvent with no toEncodable
+    // fallback — throws on them, taking the whole event down. Stringify them
+    // ("Infinity"/"NaN"/…) so the event still encodes. `int`s are always
+    // finite, so this only rewrites the pathological doubles.
+    return value.isFinite ? value : value.toString();
+  }
+  if (value == null || value is bool || value is String) {
     return value;
   }
   if (depth > maxDepth) return value.toString();
@@ -263,9 +271,12 @@ Object? _parseValue(String s) {
   if (s == 'true') return true;
   if (s == 'false') return false;
 
-  // Try numeric
+  // Try numeric. `num.tryParse` accepts 'Infinity'/'-Infinity'/'NaN' and
+  // returns a non-finite double; those can't be json.encode'd (and
+  // developer.postEvent has no toEncodable fallback), so keep the original
+  // string form for them rather than emitting a live non-finite number.
   final numVal = num.tryParse(s);
-  if (numVal != null) return numVal;
+  if (numVal != null) return numVal.isFinite ? numVal : s;
 
   // Try ClassName(...) recursive parse
   final nestedObject = _parseToString(s);

--- a/packages/riverpod_devtools/test/serialization_test.dart
+++ b/packages/riverpod_devtools/test/serialization_test.dart
@@ -49,6 +49,28 @@ class ModelWithUnsafeToJson {
       };
 }
 
+/// A model whose toJson() contains non-finite doubles, which json.encode
+/// cannot handle (and developer.postEvent has no toEncodable fallback).
+class ModelWithNonFiniteToJson {
+  Map<String, Object?> toJson() => {
+        'ratio': double.infinity,
+        'delta': double.negativeInfinity,
+        'score': double.nan,
+        'finite': 3.5,
+        'nested': [
+          double.infinity,
+          {'inner': double.nan},
+        ],
+      };
+}
+
+/// A model whose toString() carries a non-finite number in the
+/// "ClassName(prop: val)" shape the serializer parses into structure.
+class StatsWithInfinity {
+  @override
+  String toString() => 'Stats(ratio: Infinity, count: 3)';
+}
+
 void main() {
   group('serializeValue', () {
     test('handles null', () {
@@ -127,6 +149,52 @@ void main() {
       // The whole event must survive json.encode without a toEncodable
       // fallback, as developer.postEvent has none.
       expect(() => jsonEncode(result), returnsNormally);
+    });
+
+    group('non-finite numbers (Infinity/-Infinity/NaN)', () {
+      test('a top-level non-finite double is encodable', () {
+        for (final value in [
+          double.infinity,
+          double.negativeInfinity,
+          double.nan,
+        ]) {
+          final result = serializeValue(value);
+          // The number itself is only carried as its `string` form, which is
+          // json-safe; the event must survive json.encode regardless.
+          expect(() => jsonEncode(result), returnsNormally,
+              reason: 'failed for $value');
+        }
+      });
+
+      test('sanitizes non-finite doubles in toJson() output', () {
+        final result = serializeValue(ModelWithNonFiniteToJson());
+        final value = result['value'] as Map;
+
+        expect(value['ratio'], 'Infinity');
+        expect(value['delta'], '-Infinity');
+        expect(value['score'], 'NaN');
+        // Finite numbers are left as-is.
+        expect(value['finite'], 3.5);
+
+        final nested = value['nested'] as List;
+        expect(nested[0], 'Infinity');
+        expect((nested[1] as Map)['inner'], 'NaN');
+
+        // The whole event must survive json.encode without a toEncodable
+        // fallback, as developer.postEvent has none.
+        expect(() => jsonEncode(result), returnsNormally);
+      });
+
+      test('does not parse a non-finite toString() number into a live double',
+          () {
+        final result = serializeValue(StatsWithInfinity());
+        final value = result['value'] as Map;
+
+        // The non-finite field stays a string; the finite one still parses.
+        expect(value['ratio'], 'Infinity');
+        expect(value['count'], 3);
+        expect(() => jsonEncode(result), returnsNormally);
+      });
     });
 
     test('handles circular references', () {


### PR DESCRIPTION
## Summary

Fixes #111.

A provider value containing `double.infinity`, `double.negativeInfinity`, or `double.nan` could throw an uncaught `Converting object to an encodable object failed: Infinity` from `developer.postEvent`. Those are valid `num`s, but Dart's `json.encode` (which `postEvent` uses with **no `toEncodable` fallback**) rejects them — so the whole event, and the debug app, goes down. Removing the observer stops the crash, which is what the reporter observed.

## Root cause

Every value embedded in an event payload goes through `serializeValue`, and a plain non-finite double is already safe there (it's only carried as its `string` form). But two serializer sub-paths let a **raw** non-finite number slip into the payload — exactly as the reporter diagnosed:

1. **`_jsonSafe`** (the `toJson()` sanitizer) treated all `num` as JSON-safe, so a `toJson()` returning e.g. `{'ratio': double.infinity}` passed the non-finite double straight through.
2. **`_parseValue`** (the `toString()` parser) returned `num.tryParse('Infinity')`, which is a live non-finite double, for an object whose `toString()` is e.g. `Stats(ratio: Infinity)`.

## Fix

`packages/riverpod_devtools/lib/src/utils/serialization.dart`:
- `_jsonSafe`: non-finite doubles are rewritten to their string form (`"Infinity"` / `"-Infinity"` / `"NaN"`). `int`s are always finite, so only the pathological doubles are touched.
- `_parseValue`: a parsed non-finite number keeps its original string form instead of being emitted as a live non-finite double.

Finite numbers are unchanged, so the wire format is unaffected for all normal values (the decoder in the extension and `compact.dart` already handle string values). This also protects the MCP HTTP endpoints (`/logs`, `/providers`, …), which encode the same serialized payloads.

## Tests

Added a `non-finite numbers (Infinity/-Infinity/NaN)` group to `serialization_test.dart`:
- a top-level non-finite double serializes to a `json.encode`-able result;
- `_jsonSafe`: non-finite leaves in `toJson()` output (including nested in a list/map) become `"Infinity"`/`"-Infinity"`/`"NaN"` while finite ones stay numeric, and the whole event encodes;
- `_parseValue`: a `Stats(ratio: Infinity, count: 3)` `toString()` yields `ratio: "Infinity"` (string) and `count: 3` (still a number), and encodes.

## Test plan

- [ ] `flutter test` in `packages/riverpod_devtools` (this sandbox has no Flutter/Dart SDK, so I couldn't run it — please confirm the new `serialization_test.dart` cases and the existing suite pass)
- [ ] `flutter analyze` in `packages/riverpod_devtools`

Backend/serializer only — no UI change, so no extension screenshot is needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7RBZhMbgazKMNFeZ5yfqN)_