### PR TITLE
chore: release 1.1.1

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.1.1
 
 - **Fix: non-finite numbers no longer crash the observer.** A provider value
   containing `double.infinity`, `double.negativeInfinity`, or `double.nan`

--- a/packages/riverpod_devtools/README.md
+++ b/packages/riverpod_devtools/README.md
@@ -51,7 +51,7 @@ See [MCP.md](MCP.md) for setup — it takes one `.mcp.json` entry.
 
     ```yaml
     dependencies:
-      riverpod_devtools: ^1.1.0
+      riverpod_devtools: ^1.1.1
       flutter_riverpod: '>=2.3.0 <4.0.0'
     ```
 

--- a/packages/riverpod_devtools/extension/devtools/config.yaml
+++ b/packages/riverpod_devtools/extension/devtools/config.yaml
@@ -1,4 +1,4 @@
 name: riverpod_devtools
 issueTracker: https://github.com/yutsuki3/riverpod_devtools/issues
-version: 1.1.0
+version: 1.1.1
 materialIconCodePoint: "0xe97a"

--- a/packages/riverpod_devtools/lib/src/mcp_constants.dart
+++ b/packages/riverpod_devtools/lib/src/mcp_constants.dart
@@ -20,4 +20,4 @@ Iterable<int> get riverpodDevToolsMcpPorts => Iterable.generate(
 
 /// The published package version, reported in the MCP initialize handshake.
 /// Kept in sync by tool/release.sh — do not edit by hand during a release.
-const String riverpodDevToolsVersion = '1.1.0';
+const String riverpodDevToolsVersion = '1.1.1';

--- a/packages/riverpod_devtools/pubspec.yaml
+++ b/packages/riverpod_devtools/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_devtools
 description: DevTools extension for Riverpod - inspect providers in real-time, now with MCP support for AI coding tools.
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/yutsuki3/riverpod_devtools
 homepage: https://github.com/yutsuki3/riverpod_devtools
 issue_tracker: https://github.com/yutsuki3/riverpod_devtools/issues

--- a/packages/riverpod_devtools_extension/pubspec.yaml
+++ b/packages/riverpod_devtools_extension/pubspec.yaml
@@ -2,7 +2,7 @@ name: riverpod_devtools_extension
 description: DevTools extension UI for riverpod_devtools
 publish_to: 'none'
 
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
## Summary

Prepares the **1.1.1** patch release (bug fixes + docs only, no API changes).

Changes bundled since 1.1.0:
- **Fix**: non-finite numbers (`Infinity`/`-Infinity`/`NaN`) in a provider value no longer crash the observer via `developer.postEvent` (#111).
- **Fix**: the static analyzer now detects `@riverpod` code-generated providers, so their static dependencies attach at runtime instead of reporting `name_mismatch` (#105).
- **Docs**: MCP setup for monorepo/subdirectory/FVM apps (#106) and an MCP connection diagnostic checklist (#107).

## What this PR does (the version sync)

Mirrors the 5 version bumps `tool/release.sh` performs, plus the manual CHANGELOG fold:
- `packages/riverpod_devtools/pubspec.yaml` → `1.1.1`
- `packages/riverpod_devtools/extension/devtools/config.yaml` → `1.1.1`
- `packages/riverpod_devtools_extension/pubspec.yaml` → `1.1.1`
- `packages/riverpod_devtools/lib/src/mcp_constants.dart` (`riverpodDevToolsVersion`, used by the MCP handshake) → `1.1.1`
- `packages/riverpod_devtools/README.md` install snippet → `^1.1.1`
- `CHANGELOG.md`: `Unreleased` folded into a `1.1.1` entry

The root README **Version Compatibility** table gets no new row (the Flutter/riverpod constraints didn't change since 1.1.0). A `grep` for leftover `1.1.0` (excluding build output, CHANGELOG history, and the dependency-JSON format version) comes back clean.

## ⚠️ Steps that must be run locally (no Flutter/Dart SDK or pub.dev credentials in the CI/remote env)

This PR only does the reversible prep. The remaining `tool/release.sh` / CLAUDE.md checklist steps need a local Flutter SDK and pub.dev auth:

1. **Rebuild the bundled extension** (only strictly needed if it drifts — no extension UI source changed since 1.1.0, so `extension/devtools/build/` is functionally current; rebuilding is still the documented path):
   `cd packages/riverpod_devtools_extension && flutter build web --release` then copy into `packages/riverpod_devtools/extension/devtools/build/` (or just run `tool/release.sh 1.1.1` locally to redo the sync + build in one shot on top of `main`).
2. **Verify**: `flutter analyze && flutter test` in **both** packages (extension tests need `--platform chrome`).
3. `cd packages/riverpod_devtools && flutter pub publish --dry-run`
4. `flutter pub publish`
5. `git tag v1.1.1 && git push origin v1.1.1`

## Test plan

- [ ] `flutter analyze` + `flutter test` pass in both packages
- [ ] `flutter pub publish --dry-run` is clean
- [ ] Bundled extension build reviewed / regenerated if needed


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7RBZhMbgazKMNFeZ5yfqN)_