### PR TITLE
fix: ensure the bundled extension build ships fully in pub publish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,9 +18,17 @@ build_web/
 # Claude Code
 .claude/
 
-# Extension build output (generated)
-
+# Extension build output (generated). This directory is the bundled DevTools
+# extension and SHIPS inside the published package, so it must stay tracked and
+# be included by `flutter pub publish` — the blanket `build/` rule above would
+# otherwise drop it. Re-include the whole subtree: the `/**` line is required
+# in addition to the directory line because `pub`'s file selection is stricter
+# than git's and does not re-include nested files from a directory negation
+# alone. Without it, pub silently drops some canvaskit variants
+# (e.g. canvaskit/experimental_webparagraph/, canvaskit/wimp.*) from the
+# published archive, and `pub publish` warns that checked-in files are ignored.
 !packages/riverpod_devtools/extension/devtools/build/
+!packages/riverpod_devtools/extension/devtools/build/**
 
 # Generated dependency metadata files
 **/riverpod_dependencies.json


### PR DESCRIPTION
## Summary

`flutter pub publish --dry-run` for 1.1.1 raised:

> 6 checked-in files are ignored by a `.gitignore`. Previous versions of Pub would include those in the published package.
> `extension/devtools/build/canvaskit/experimental_webparagraph/*`, `extension/devtools/build/canvaskit/wimp.*`

and those 6 canvaskit files were **dropped from the published archive**.

## Root cause

The repo-root `.gitignore` ignores every `build/` dir, then re-includes the bundled extension build with a directory negation:

```gitignore
build/
...
!packages/riverpod_devtools/extension/devtools/build/
```

`git` handles this correctly — `git check-ignore` confirms none of the build files are ignored. But `pub`'s file selection is stricter: a **directory** negation alone does not re-include nested files, so pub still treated part of the `build/` subtree as ignored and excluded those files from the package.

## Fix

Add the explicit subtree negation so pub re-includes the whole bundled build too:

```gitignore
!packages/riverpod_devtools/extension/devtools/build/
!packages/riverpod_devtools/extension/devtools/build/**
```

Verified locally with `git check-ignore`:
- ✅ every file under `extension/devtools/build/` (including `canvaskit/wimp.js`, `canvaskit/experimental_webparagraph/canvaskit.js`, `main.dart.js`, `assets/NOTICES`) is **included**;
- ✅ unrelated `build/` output elsewhere (`packages/riverpod_devtools_extension/build/`, `example/build/`) stays **ignored** — the rule is not over-broadened.

## Verification before publishing

Because pub can't be run in this environment, please confirm on the release machine after merging: a fresh `flutter pub publish --dry-run` should now list the `canvaskit/experimental_webparagraph/` and `canvaskit/wimp.*` files in the archive tree and no longer emit the "checked-in files are ignored" warning.

## Note on the other dry-run warning

The separate "20 checked-in files are modified in git" warning is **not** addressed here — it only means the locally rebuilt extension hasn't been committed yet. Committing the release (the rebuilt `extension/devtools/build/` + version bumps) before running the dry-run / publish clears it; it isn't a repo-config issue.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7RBZhMbgazKMNFeZ5yfqN)_