### PR TITLE
chore: pin the Flutter SDK for FVM with a repo-level .fvmrc

### DIFF
--- a/.fvmrc
+++ b/.fvmrc
@@ -1,0 +1,3 @@
+{
+  "flutter": "stable"
+}


### PR DESCRIPTION
## Summary

Running `tool/release.sh` under FVM failed in two stages:

1. `Null check` / `ParsedYamlException: Not a map` — FVM walked up the directory tree resolving the project's Flutter version and choked on a stray/empty ancestor `pubspec.yaml` above the checkout.
2. After upgrading FVM: `ProcessException: /bin/sh: flutter: command not found` — FVM found no pinned version and fell back to a `flutter` on `PATH`, which doesn't exist on an FVM-only machine.

Both stem from the repo having **no pinned Flutter version** for FVM.

## Change

Add a repo-root `.fvmrc` pinning the SDK:

```json
{
  "flutter": "stable"
}
```

- FVM now resolves a version immediately and **stops walking at the repo root**, so it never reaches the stray ancestor pubspec.
- `fvm flutter …` (and therefore `tool/release.sh`) knows which SDK to run — no more "command not found".

**Version choice:** `stable` matches CI (`subosito/flutter-action` runs on the stable channel). Swap it for a specific version (e.g. `"flutter": "3.35.0"`) if you prefer fully reproducible pinning.

**No side effects:**
- CI doesn't use FVM, so `.fvmrc` is inert there.
- `.fvmrc` lives at the repo root, outside `packages/riverpod_devtools/`, so it is **never included in the published package**.

## Local step still required

`.fvmrc` only *pins* the version — the SDK must be installed locally once:

```bash
fvm install         # installs the pinned "stable"
# then
tool/release.sh 1.1.1
```

(Equivalently, `fvm use stable` installs + pins in one go.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7RBZhMbgazKMNFeZ5yfqN)_