### PR TITLE
fix: bridge analyzer 14's ArgumentList.arguments type split

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -14,6 +14,18 @@
   itself (matching the previous per-file behavior), and the pipeline no
   longer needs a resolvable SDK, which also made `analyze()` end-to-end
   testable.
+- **Fix: `dart run riverpod_devtools:analyze` no longer fails to compile on
+  `analyzer` 14+.** `ArgumentList.arguments`'s element type changed from
+  `NodeList<Expression>` to `NodeList<Argument>` (a new sealed interface
+  implemented by both `Expression` and the new `NamedArgument`; the old
+  `NamedExpression` was removed) — a genuine breaking type change that can't
+  be bridged with a single static type, since `Argument`/`NamedArgument`
+  don't exist pre-14 and `NamedExpression` doesn't exist on 14+. The
+  `ref.watch`/`read`/`listen` argument extractor now resolves the argument's
+  expression dynamically instead of relying on either shape, restoring
+  compatibility across the package's full declared `analyzer: >=6.0.0
+  <15.0.0` range instead of breaking on whichever version `pub get`
+  resolves.
 
 ## 1.1.1
 

--- a/packages/riverpod_devtools/lib/src/cli/simple_dependency_extractor.dart
+++ b/packages/riverpod_devtools/lib/src/cli/simple_dependency_extractor.dart
@@ -38,7 +38,8 @@ class _RefCallVisitor extends RecursiveAstVisitor<void> {
 
     // Check for ref.watch/read/listen
     if (_isRefTarget(target) && _isRefMethod(methodName)) {
-      final providerName = _extractProviderName(node.argumentList.arguments);
+      final providerName =
+          _extractProviderName(node.argumentList.arguments.toList());
       if (providerName != null) {
         final dependencyType = _getDependencyType(methodName);
         if (dependencyType != null) {
@@ -69,11 +70,43 @@ class _RefCallVisitor extends RecursiveAstVisitor<void> {
   }
 
   /// Extract provider name from method arguments
-  String? _extractProviderName(NodeList<Expression> arguments) {
+  String? _extractProviderName(List<Object?> arguments) {
     if (arguments.isEmpty) return null;
 
-    final firstArg = arguments.first;
+    final firstArg = _asExpression(arguments.first);
+    if (firstArg == null) return null;
     return _getProviderNameFromExpression(firstArg);
+  }
+
+  /// `ArgumentList.arguments`'s element type changed across analyzer
+  /// versions: pre-14 it's `NodeList<Expression>` (a positional argument
+  /// simply *is* an Expression); 14+ it's `NodeList<Argument>`, a new sealed
+  /// interface implemented by both `Expression` (positional) and the new
+  /// `NamedArgument` (`.argumentExpression` unwraps to the value). This is a
+  /// genuine breaking type change — `Argument`/`NamedArgument` don't exist
+  /// pre-14, and the old `NamedExpression` was removed in 14 — so it can't
+  /// be bridged with a single static type; resolve dynamically instead, the
+  /// same way `ClassDeclaration.name`/`.members` are bridged in analyzer.dart.
+  ///
+  /// A positional argument's *runtime* type is `Expression` on every
+  /// version (14+ only added the `Argument` interface on top of it), so the
+  /// fast path below handles the common case — including on 14+ — without
+  /// any dynamic call. `ref.watch`/`read`/`listen` never take a named
+  /// argument, so the `.argumentExpression` fallback (14+ only) is
+  /// unreachable in practice; it exists purely so a genuinely-named argument
+  /// degrades to "not extracted" instead of being silently mismatched.
+  Expression? _asExpression(Object? argument) {
+    if (argument is Expression) return argument;
+    final dynamic dynArg = argument;
+    try {
+      // ignore: avoid_dynamic_calls
+      final expr = dynArg.argumentExpression;
+      if (expr is Expression) return expr;
+    } catch (_) {
+      // Not present on this analyzer version (pre-14) or an unrecognized
+      // argument shape; treat as unextractable.
+    }
+    return null;
   }
 
   /// Get provider name from an expression

--- a/packages/riverpod_devtools/test/cli_dependency_extractor_test.dart
+++ b/packages/riverpod_devtools/test/cli_dependency_extractor_test.dart
@@ -150,6 +150,25 @@ final b = Provider((ref) {
       expect(deps, isEmpty);
     });
 
+    test('a syntactically named argument does not throw', () {
+      // Not valid Riverpod usage (ref.watch takes one positional argument),
+      // but still valid Dart syntax, and ArgumentList.arguments' element
+      // shape for a named argument differs across analyzer versions (it was
+      // `NamedExpression implements Expression` pre-14, `NamedArgument
+      // implements Argument` — a different interface — from 14 on). The
+      // exact outcome is version-dependent (older analyzers can't unwrap it
+      // and record nothing; 14+ can and does), but extraction must never
+      // throw either way.
+      expect(
+        () => _extract('''
+final b = Provider((ref) {
+  return ref.watch(name: a);
+});
+'''),
+        returnsNormally,
+      );
+    });
+
     test('records a source location for each dependency', () {
       final deps = _extract('''
 final b = Provider((ref) {


### PR DESCRIPTION
## Summary

Discovered while benchmarking the analyze CLI's performance: `dart run riverpod_devtools:analyze` fails to **compile** whenever `pub get` resolves `analyzer` 14+, which is within the package's own declared `analyzer: >=6.0.0 <15.0.0` constraint.

```
lib/src/cli/simple_dependency_extractor.dart:41:67: Error: The argument type
'NodeList<Argument>' can't be assigned to the parameter type
'NodeList<Expression>'.
```

## Root cause

`ArgumentList.arguments`'s element type changed between analyzer versions:

- **pre-14**: `NodeList<Expression>` — a positional argument simply *is* an `Expression`; a named one is `NamedExpression implements Expression`.
- **14+**: `NodeList<Argument>` — a new sealed interface. `Expression` now also implements `Argument` (unifying positional args under it), and named arguments became `NamedArgument implements Argument` with an `.argumentExpression` getter. `NamedExpression` was **removed entirely**.

This is a genuine breaking type change, not just a widened signature — `Argument`/`NamedArgument`/`.argumentExpression` don't exist pre-14, and `NamedExpression` doesn't exist on 14+, so no single static type in our source can reference both API shapes at once.

## Fix

`_extractProviderName`'s parameter is now `List<Object?>` instead of `NodeList<Expression>`, and a new `_asExpression` helper resolves each argument to its `Expression` dynamically — the same bridging idiom already used for `ClassDeclaration.name`/`.members` in `analyzer.dart` (added when we hit an equivalent analyzer-14 break there).

Importantly, this needs **no dynamic call on the common path**: a positional argument's *runtime* type is `Expression` on every analyzer version (14+ only adds the `Argument` interface on top of the same object), so `argument is Expression` handles `ref.watch`/`read`/`listen`'s normal usage — the only pattern real Riverpod code produces — without ever touching `dynamic`. The `.argumentExpression` fallback (dynamic, 14+ only) exists purely so a syntactically named argument (invalid Riverpod usage, but valid Dart syntax) degrades safely instead of crashing.

## Alternative considered

Capping the pubspec constraint to `analyzer: >=6.0.0 <14.0.0` instead. Rejected: the wide range is a deliberate project design choice (see CLAUDE.md), and capping would newly block `pub get` entirely for anyone whose *other* dependencies already require analyzer 14+ — worse than today's "the tool itself fails to compile," and it doesn't prevent the same class of break recurring on the next analyzer bump (as already happened once for `ClassDeclaration`).

## Verification

This sandbox has no Flutter/Dart SDK for the package's own `flutter_test`-based suite, so I built an isolated pure-Dart sandbox with the actual `analyzer.dart` + `simple_dependency_extractor.dart` source, pinned once to `analyzer: 12.1.0` and once to `14.1.0`, and ran real `ref.watch/read/listen` extraction end-to-end both times:

- **Identical output on real usage** both versions: 3 providers, 4 dependencies, same names/kinds (`.watch`, `.read` via `.select()`, `.listen`).
- **Named-argument edge case** (`ref.watch(name: a)` — invalid Riverpod usage, but valid Dart syntax): no crash on either version. 12.1.0 can't unwrap it (records nothing, matching prior behavior exactly); 14.1.0 does unwrap it via the new fallback (a strict improvement, not a regression). The new test asserts `returnsNormally` rather than a specific analyzer-version-dependent outcome.

## Tests

Added `cli_dependency_extractor_test.dart`: "a syntactically named argument does not throw".

## Test plan

- [ ] `flutter test` in `packages/riverpod_devtools` (no SDK in this sandbox for the `flutter_test`-based suite — verified independently in a pure-Dart sandbox instead, see above)
- [ ] `flutter analyze`
- [ ] Optional: `dart pub get` with a `dependency_overrides: {analyzer: 14.1.0}` and re-run `dart run riverpod_devtools:analyze` on a real project to confirm it now compiles and produces the same `riverpod_dependencies.json`

CLI/backend only — no UI change, no extension screenshot needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7RBZhMbgazKMNFeZ5yfqN)_