### PR TITLE
chore: release 1.1.2

### DIFF
--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.1.2
 
 - **Perf: `dart run riverpod_devtools:analyze` is dramatically faster on
   large projects.** The CLI resolved every file semantically

--- a/packages/riverpod_devtools/README.md
+++ b/packages/riverpod_devtools/README.md
@@ -51,7 +51,7 @@ See [MCP.md](MCP.md) for setup — it takes one `.mcp.json` entry.
 
     ```yaml
     dependencies:
-      riverpod_devtools: ^1.1.1
+      riverpod_devtools: ^1.1.2
       flutter_riverpod: '>=2.3.0 <4.0.0'
     ```
 

--- a/packages/riverpod_devtools/extension/devtools/config.yaml
+++ b/packages/riverpod_devtools/extension/devtools/config.yaml
@@ -1,4 +1,4 @@
 name: riverpod_devtools
 issueTracker: https://github.com/yutsuki3/riverpod_devtools/issues
-version: 1.1.1
+version: 1.1.2
 materialIconCodePoint: "0xe97a"

--- a/packages/riverpod_devtools/lib/src/mcp_constants.dart
+++ b/packages/riverpod_devtools/lib/src/mcp_constants.dart
@@ -20,4 +20,4 @@ Iterable<int> get riverpodDevToolsMcpPorts => Iterable.generate(
 
 /// The published package version, reported in the MCP initialize handshake.
 /// Kept in sync by tool/release.sh — do not edit by hand during a release.
-const String riverpodDevToolsVersion = '1.1.1';
+const String riverpodDevToolsVersion = '1.1.2';

--- a/packages/riverpod_devtools/pubspec.yaml
+++ b/packages/riverpod_devtools/pubspec.yaml
@@ -1,6 +1,6 @@
 name: riverpod_devtools
 description: DevTools extension for Riverpod - inspect providers in real-time, now with MCP support for AI coding tools.
-version: 1.1.1
+version: 1.1.2
 repository: https://github.com/yutsuki3/riverpod_devtools
 homepage: https://github.com/yutsuki3/riverpod_devtools
 issue_tracker: https://github.com/yutsuki3/riverpod_devtools/issues

--- a/packages/riverpod_devtools_extension/pubspec.yaml
+++ b/packages/riverpod_devtools_extension/pubspec.yaml
@@ -2,7 +2,7 @@ name: riverpod_devtools_extension
 description: DevTools extension UI for riverpod_devtools
 publish_to: 'none'
 
-version: 1.1.1
+version: 1.1.2
 
 environment:
   sdk: ^3.5.0


### PR DESCRIPTION
## Summary

Prepares the **1.1.2** patch release (one perf fix, one compatibility fix, no API changes).

Changes bundled since 1.1.1:
- **Perf**: `dart run riverpod_devtools:analyze` switched from full semantic resolution per file to a syntax-only parse (the extraction never used resolved types/elements) — typically minutes → well under a second on provider-heavy apps. Benchmarked at 17–32x faster on synthetic provider-heavy projects; real numbers should be larger since a real app also resolves flutter/riverpod/every other dependency per file under the old pipeline, which this synthetic benchmark didn't include. (#117)
- **Fix**: `dart run riverpod_devtools:analyze` no longer fails to compile when `pub get` resolves `analyzer` 14+. `ArgumentList.arguments`'s element type changed across analyzer versions in a way that can't be bridged with a single static type (`Argument`/`NamedArgument` don't exist pre-14, `NamedExpression` was removed on 14+); the argument extractor now resolves it dynamically, restoring compatibility across the package's full declared `analyzer: >=6.0.0 <15.0.0` range. (#118)

## What this PR does (the version sync)

Mirrors the 5 version bumps `tool/release.sh` performs, plus the manual CHANGELOG fold:
- `packages/riverpod_devtools/pubspec.yaml` → `1.1.2`
- `packages/riverpod_devtools/extension/devtools/config.yaml` → `1.1.2`
- `packages/riverpod_devtools_extension/pubspec.yaml` → `1.1.2`
- `packages/riverpod_devtools/lib/src/mcp_constants.dart` (`riverpodDevToolsVersion`, used by the MCP handshake) → `1.1.2`
- `packages/riverpod_devtools/README.md` install snippet → `^1.1.2`
- `CHANGELOG.md`: `Unreleased` folded into a `1.1.2` entry

No `pubspec.yaml` dependency constraints changed since 1.1.1 (verified via diff), so the root README's **Version Compatibility** table gets no new row. A `grep` for leftover `1.1.1` (excluding build output, CHANGELOG history, and the dependency-JSON format version) comes back clean.

## Steps that must be run locally (no Flutter/Dart SDK or pub.dev credentials in this environment)

Following the same flow as 1.1.1:

1. `git pull` (bring in this PR's version sync)
2. `tool/release.sh 1.1.2` (rebuilds the bundled extension — `.fvmrc` + the FVM-aware launcher from #114/#116 should make this work out of the box now)
3. `flutter analyze && flutter test` in **both** packages (extension needs `--platform chrome`)
4. If you don't want to commit the rebuilt extension to `main`, `git checkout -- packages/riverpod_devtools/extension/devtools/build/` reverts to the tracked build (unchanged since 1.1.1, no extension UI source has changed) before publishing — same approach used for 1.1.1.
5. `cd packages/riverpod_devtools && flutter pub publish --dry-run` (should show 0 warnings, per the #115 gitignore fix)
6. `flutter pub publish`
7. `git tag v1.1.2 && git push origin v1.1.2`
8. Create the GitHub Release for `v1.1.2` (same format as v1.1.0/v1.1.1)

## Test plan

- [ ] `flutter analyze` + `flutter test` pass in both packages
- [ ] `flutter pub publish --dry-run` is clean (0 warnings)
- [ ] Optional: re-run `dart run riverpod_devtools:analyze` on a project using `analyzer` 14+ to confirm it now compiles and completes quickly


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7RBZhMbgazKMNFeZ5yfqN)_