### PR TITLE
Write project-relative paths in riverpod_dependencies.json

### DIFF
--- a/example/lib/riverpod_dependencies.json
+++ b/example/lib/riverpod_dependencies.json
@@ -5,7 +5,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/todo_page.dart",
+        "file": "lib/pages/todo_page.dart",
         "line": 25,
         "column": 7
       }
@@ -15,7 +15,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/lifecycle_page.dart",
+        "file": "lib/pages/lifecycle_page.dart",
         "line": 5,
         "column": 7
       }
@@ -25,7 +25,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "file": "lib/pages/dependencies_page.dart",
         "line": 5,
         "column": 7
       }
@@ -38,14 +38,14 @@
           "providerName": "authTokenProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "file": "lib/pages/dependencies_page.dart",
             "line": 21,
             "column": 19
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "file": "lib/pages/dependencies_page.dart",
         "line": 19,
         "column": 7
       }
@@ -58,14 +58,14 @@
           "providerName": "userIdProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "file": "lib/pages/dependencies_page.dart",
             "line": 30,
             "column": 20
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "file": "lib/pages/dependencies_page.dart",
         "line": 28,
         "column": 7
       }
@@ -78,14 +78,14 @@
           "providerName": "userIdProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "file": "lib/pages/dependencies_page.dart",
             "line": 39,
             "column": 20
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "file": "lib/pages/dependencies_page.dart",
         "line": 37,
         "column": 7
       }
@@ -98,7 +98,7 @@
           "providerName": "userNameProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "file": "lib/pages/dependencies_page.dart",
             "line": 48,
             "column": 18
           }
@@ -107,14 +107,14 @@
           "providerName": "userEmailProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "file": "lib/pages/dependencies_page.dart",
             "line": 49,
             "column": 19
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "file": "lib/pages/dependencies_page.dart",
         "line": 46,
         "column": 7
       }
@@ -124,7 +124,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "file": "lib/pages/dependencies_page.dart",
         "line": 59,
         "column": 7
       }
@@ -137,14 +137,14 @@
           "providerName": "counterProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "file": "lib/pages/dependencies_page.dart",
             "line": 75,
             "column": 19
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "file": "lib/pages/dependencies_page.dart",
         "line": 73,
         "column": 7
       }
@@ -157,7 +157,7 @@
           "providerName": "doubleCounterProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "file": "lib/pages/dependencies_page.dart",
             "line": 84,
             "column": 25
           }
@@ -166,14 +166,14 @@
           "providerName": "counterProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+            "file": "lib/pages/dependencies_page.dart",
             "line": 85,
             "column": 26
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/dependencies_page.dart",
+        "file": "lib/pages/dependencies_page.dart",
         "line": 82,
         "column": 7
       }
@@ -183,7 +183,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/performance_page.dart",
+        "file": "lib/pages/performance_page.dart",
         "line": 12,
         "column": 7
       }
@@ -193,7 +193,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/performance_page.dart",
+        "file": "lib/pages/performance_page.dart",
         "line": 22,
         "column": 7
       }
@@ -203,7 +203,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/performance_page.dart",
+        "file": "lib/pages/performance_page.dart",
         "line": 33,
         "column": 7
       }
@@ -213,7 +213,7 @@
       "providerType": "FutureProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/async_page.dart",
+        "file": "lib/pages/async_page.dart",
         "line": 7,
         "column": 7
       }
@@ -223,7 +223,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/custom_class_page.dart",
+        "file": "lib/pages/custom_class_page.dart",
         "line": 46,
         "column": 7
       }
@@ -233,7 +233,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/example/lib/pages/collections_page.dart",
+        "file": "lib/pages/collections_page.dart",
         "line": 27,
         "column": 7
       }

--- a/packages/riverpod_devtools/CHANGELOG.md
+++ b/packages/riverpod_devtools/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+- **Fix: `dart run riverpod_devtools:analyze` writes project-relative file
+  paths.** `riverpod_dependencies.json` recorded every `location.file` as an
+  absolute path of the machine that ran the analyzer, so the generated file
+  (which lives in `lib/` and is typically committed) churned in git on every
+  machine and checkout location. Locations are now relative to the project
+  root (e.g. `lib/pages/home.dart`) with `/` separators on every platform,
+  making the output reproducible. Only the recorded paths change — provider
+  and dependency extraction is untouched. Re-run
+  `dart run riverpod_devtools:analyze` once to migrate an existing file.
+
 ## 1.1.2
 
 - **Perf: `dart run riverpod_devtools:analyze` is dramatically faster on

--- a/packages/riverpod_devtools/example/lib/riverpod_dependencies.json
+++ b/packages/riverpod_devtools/example/lib/riverpod_dependencies.json
@@ -5,7 +5,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/main.dart",
+        "file": "lib/main.dart",
         "line": 14,
         "column": 7
       }
@@ -15,7 +15,7 @@
       "providerType": "NotifierProvider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/main.dart",
+        "file": "lib/main.dart",
         "line": 23,
         "column": 7
       }
@@ -28,14 +28,14 @@
           "providerName": "counterProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "file": "lib/providers.dart",
             "line": 6,
             "column": 17
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "file": "lib/providers.dart",
         "line": 5,
         "column": 7
       }
@@ -48,7 +48,7 @@
           "providerName": "counterProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "file": "lib/providers.dart",
             "line": 12,
             "column": 17
           }
@@ -57,14 +57,14 @@
           "providerName": "nameProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "file": "lib/providers.dart",
             "line": 13,
             "column": 16
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "file": "lib/providers.dart",
         "line": 11,
         "column": 7
       }
@@ -77,14 +77,14 @@
           "providerName": "counterProvider",
           "type": "read",
           "location": {
-            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "file": "lib/providers.dart",
             "line": 19,
             "column": 17
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "file": "lib/providers.dart",
         "line": 18,
         "column": 7
       }
@@ -97,14 +97,14 @@
           "providerName": "nameProvider",
           "type": "watch",
           "location": {
-            "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+            "file": "lib/providers.dart",
             "line": 25,
             "column": 16
           }
         }
       ],
       "location": {
-        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "file": "lib/providers.dart",
         "line": 24,
         "column": 7
       }
@@ -114,7 +114,7 @@
       "providerType": "Provider",
       "dependencies": [],
       "location": {
-        "file": "/home/user/riverpod_devtools/packages/riverpod_devtools/example/lib/providers.dart",
+        "file": "lib/providers.dart",
         "line": 31,
         "column": 7
       }

--- a/packages/riverpod_devtools/lib/src/cli/analyzer.dart
+++ b/packages/riverpod_devtools/lib/src/cli/analyzer.dart
@@ -58,7 +58,9 @@ class RiverpodAnalyzer {
       // Analyze all files
       final allMetadata = <ProviderMetadata>[];
       for (final file in dartFiles) {
-        allMetadata.addAll(_analyzeFile(file));
+        allMetadata.addAll(
+          _analyzeFile(file, _projectRelativePath(file.path, currentDir.path)),
+        );
       }
 
       // Generate JSON
@@ -88,6 +90,14 @@ class RiverpodAnalyzer {
     }
   }
 
+  // The JSON must be reproducible across machines and checkout locations —
+  // it lives in lib/ and is typically committed — so locations are recorded
+  // relative to the project root, with `/` separators on every platform.
+  String _projectRelativePath(String filePath, String projectRoot) {
+    final relative = path.relative(filePath, from: projectRoot);
+    return path.split(relative).join('/');
+  }
+
   // Syntax-only parse, on purpose. [ProviderVisitor] and
   // [SimpleDependencyExtractor] match purely on AST shape (provider patterns
   // in initializers, `ref.watch/read/listen` by name, `@riverpod` by
@@ -97,14 +107,14 @@ class RiverpodAnalyzer {
   // that was entirely unused. On provider-heavy apps that made
   // `dart run riverpod_devtools:analyze` take minutes; a plain parse is
   // proportional to file size only and produces the identical output.
-  List<ProviderMetadata> _analyzeFile(File file) {
+  List<ProviderMetadata> _analyzeFile(File file, String relativePath) {
     try {
       final result = parseFile(
         path: file.path,
         featureSet: FeatureSet.latestLanguageVersion(),
         throwIfDiagnostics: false,
       );
-      final visitor = ProviderVisitor(file.path);
+      final visitor = ProviderVisitor(relativePath);
       result.unit.visitChildren(visitor);
       return visitor.providers;
     } catch (_) {

--- a/packages/riverpod_devtools/test/cli_analyzer_run_test.dart
+++ b/packages/riverpod_devtools/test/cli_analyzer_run_test.dart
@@ -74,6 +74,38 @@ class VersionManager extends _\$VersionManager {
     expect(json['version'], '1.0.0'); // dependency-JSON FORMAT version
   });
 
+  test('records locations relative to the project root with / separators',
+      () async {
+    // Absolute paths made the committed JSON differ per machine/checkout;
+    // the output must stay byte-identical wherever it is regenerated.
+    libFile('providers.dart',
+        'final counterProvider = StateProvider<int>((ref) => 0);');
+    libFile('pages/home.dart', '''
+final doubledProvider = Provider<int>((ref) {
+  return ref.watch(counterProvider) * 2;
+});
+''');
+
+    final result = await RiverpodAnalyzer().analyze();
+
+    expect(result.success, isTrue, reason: result.error ?? '');
+
+    final json = jsonDecode(File(result.outputPath).readAsStringSync())
+        as Map<String, dynamic>;
+    final providers = (json['providers'] as List).cast<Map<String, dynamic>>();
+
+    final files = <String>{
+      for (final provider in providers)
+        (provider['location'] as Map<String, dynamic>)['file'] as String,
+      for (final provider in providers)
+        for (final dep
+            in (provider['dependencies'] as List).cast<Map<String, dynamic>>())
+          (dep['location'] as Map<String, dynamic>)['file'] as String,
+    };
+
+    expect(files, {'lib/providers.dart', 'lib/pages/home.dart'});
+  });
+
   test('skips generated files and survives a file with syntax errors',
       () async {
     libFile('good.dart', 'final aProvider = Provider<int>((ref) => 1);');


### PR DESCRIPTION
The CLI analyzer recorded every location.file as an absolute path of the
machine that ran it, so the generated JSON (which lives in lib/ and is
typically committed) churned in git across machines and checkout
locations. Locations are now relative to the project root with /
separators on every platform, making the output reproducible.

- analyzer.dart: relativize each file's path against the project root
  before it reaches ProviderVisitor / SimpleDependencyExtractor; the
  absolute path is still used for parsing and the CLI's output message.
- Rewrite the two committed example riverpod_dependencies.json files to
  the new relative form.
- Add an end-to-end regression test pinning the relative, /-separated
  contract for both provider and dependency locations.
- CHANGELOG: Unreleased entry with a one-line migration note.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RuqPbGSP4TTUGth9Y35y3X